### PR TITLE
Hollow Knight: Fix soul mismatch with Spell Twister

### DIFF
--- a/worlds/hk_rework/state_mixin.py
+++ b/worlds/hk_rework/state_mixin.py
@@ -548,7 +548,7 @@ class CastSpellVariable(RCStateVariable):
             if check:
                 self.do_all_casts(24, reserves, stateST)
                 if not stateST["CANNOTREGAINSOUL"] and self.after:
-                    self.recover_soul(sum(self.casts) * 33, stateST)
+                    self.recover_soul(sum(self.casts) * 24, stateST)
                 yield stateST
 
     def can_exclude(self, options: HKOptions) -> bool:


### PR DESCRIPTION

## What is this fixing or adding?

There was a mismatch between the amount of soul consumed and recovered here; I checked upstream and I think it's not possible for there to be a mismatch in the amount of soul that should be passed to recover_soul here.

## How was this tested?

No

## If this makes graphical changes, please attach screenshots.

No
