### PR TITLE
Sweep rework

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 import operator
 from collections import Counter, defaultdict
+from Utils import KeyedDefaultDict
 from copy import deepcopy
 from typing import Any, ClassVar, cast
 
@@ -38,7 +39,7 @@ from .options import (
 from .resource_state_vars import ResourceStateHandler, rs_get_value
 from .resource_state_vars.cast_spell import NearbySoul
 from .rules import cost_terms
-from .state_mixin import HKLogicMixin as HKLogicMixin
+from .state_mixin import HKLogicMixin as HKLogicMixin, default_state
 from .template_world import RandomizerCoreWorld
 logger = logging.getLogger("Hollow Knight")
 
@@ -91,6 +92,7 @@ class HKWorld(RandomizerCoreWorld, World):
     rule_lookup: ClassVar[dict[str, str]] = {location["name"]: location["logic"] for location in hk_locations}
     region_lookup: ClassVar[dict[str, str]] = {location: r["name"] for r in hk_regions for location in r["locations"]}
     entrance_by_term: dict[str, list[str]]
+    entrance_state_modifier_by_term: dict[str, list[tuple[str, str]]]
 
     cached_filler_items: ClassVar[dict[int, list[str]]] = {}  # per player cache
     grub_count: int
@@ -112,6 +114,7 @@ class HKWorld(RandomizerCoreWorld, World):
         self.vanilla_shop_costs = deepcopy(vanilla_shop_costs)
         self.event_locations = deepcopy(event_locations)
         self.entrance_by_term = defaultdict(list)
+        self.entrance_state_modifier_by_term = defaultdict(list)
 
     def white_palace_exclusions(self) -> set[str]:
         exclusions = set()
@@ -225,6 +228,11 @@ class HKWorld(RandomizerCoreWorld, World):
             if item.name not in progression_effect_lookup:
                 # handle events that don't have effects by adding them as their own terms
                 state.prog_items[player][item.name] += 1
+                if item.name in self.event_locations:
+                    state._hk_per_player_sweepable_entrances[player].update(self.entrance_by_term[item.name])
+                    for entrance, modifier_id in self.entrance_state_modifier_by_term[item.name]:
+                        if entrance in state._hk_checked_state_modifiers[player]:
+                            state._hk_checked_state_modifiers[player][entrance].discard(modifier_id)
             else:
                 lookup = progression_effect_lookup[item.name]
                 add = True
@@ -239,6 +247,9 @@ class HKWorld(RandomizerCoreWorld, World):
 
                 for term in effects.keys():
                     state._hk_per_player_sweepable_entrances[player].update(self.entrance_by_term[term])
+                    for entrance, modifier_id in self.entrance_state_modifier_by_term[term]:
+                        if entrance in state._hk_checked_state_modifiers[player]:
+                            state._hk_checked_state_modifiers[player][entrance].discard(modifier_id)
             state._hk_stale[item.player] = True
         return item.advancement
 
@@ -287,6 +298,8 @@ class HKWorld(RandomizerCoreWorld, World):
             state._hk_per_player_sweepable_entrances[item.player] = {
                 entrance.name for entrance in self.get_region("Menu").exits
                 }
+            state._hk_checked_state_modifiers[item.player] = {}
+            state._hk_per_player_resource_states[item.player] = KeyedDefaultDict(lambda region: [default_state()] if region == "Menu" else [])
 
             state._hk_stale[item.player] = True
         return item.advancement
@@ -542,9 +555,18 @@ class HKWorld(RandomizerCoreWorld, World):
         # set hk_rule instead of access_rule because our Location class defines a custom access_rule
         if isinstance(spot, HKEntrance):
             relevant_terms = {term for clause in rule for term in clause.hk_item_requirements.keys()}
-            relevant_terms.update(
-                {term for clause in rule for s_var in clause.hk_state_requirements for term in s_var.terms}
-            )
+            tried_modifiers = set()
+            for clause in rule:
+                state_modifier_id = '; '.join(handler.term_name for handler in clause.hk_state_requirements)
+                if state_modifier_id in tried_modifiers:
+                    continue
+                tried_modifiers.add(state_modifier_id)
+                cur_terms = set()
+                for handler in clause.hk_state_requirements:
+                    cur_terms.update(handler.terms)
+                relevant_terms.update(cur_terms)
+                for term in cur_terms:
+                    self.entrance_state_modifier_by_term[term].append((spot.name,state_modifier_id))
             for term in relevant_terms:
                 # could keep this a static method by doing spot.parent_region.multiworld.worlds[spot.player] but ugh
                 self.entrance_by_term[term].append(spot.name)

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -35,12 +35,11 @@ from .options import (
     hollow_knight_options,
     shop_to_option,
 )
-from .resource_state_vars import ResourceStateHandler
+from .resource_state_vars import ResourceStateHandler, rs_get_value
 from .resource_state_vars.cast_spell import NearbySoul
 from .rules import cost_terms
 from .state_mixin import HKLogicMixin as HKLogicMixin
 from .template_world import RandomizerCoreWorld
-
 logger = logging.getLogger("Hollow Knight")
 
 
@@ -586,7 +585,7 @@ class HKWorld(RandomizerCoreWorld, World):
             # cannot deliver flower
             return False
         for state_blob in state._hk_per_player_resource_states[self.player]["GG_Waterways"]:
-            if not state_blob["NOFLOWER"]:
+            if not rs_get_value(state_blob, "NOFLOWER"):
                 # if any valid state gets us to godseeker with the flower unbroken
                 return True
         return False

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -557,7 +557,7 @@ class HKWorld(RandomizerCoreWorld, World):
             relevant_terms = {term for clause in rule for term in clause.hk_item_requirements.keys()}
             tried_modifiers = set()
             for clause in rule:
-                state_modifier_id = '; '.join(handler.term_name for handler in clause.hk_state_requirements)
+                state_modifier_id = "; ".join(handler.term_name for handler in clause.hk_state_requirements)
                 if state_modifier_id in tried_modifiers:
                     continue
                 tried_modifiers.add(state_modifier_id)

--- a/worlds/hk/classes.py
+++ b/worlds/hk/classes.py
@@ -175,22 +175,29 @@ class HKEntrance(Entrance):
         else:
             cache = state._hk_entrance_clause_cache[self.player][self.name]
 
-        # check every clause, caching item state accessibility
+        # check every clause, caching item state accessibility and tried resource state modifiers
         valid_clauses = False
+        if self.name not in state._hk_checked_state_modifiers[self.player]:
+            state._hk_checked_state_modifiers[self.player][self.name] = set()
+        terms = state._hk_checked_state_modifiers[self.player][self.name]
         for index, clause in enumerate(self.hk_rule):
             if cache[index] or state.has_all_counts(clause.hk_item_requirements, self.player):
                 cache[index] = True
-
+                cur_term = '; '.join(handler.term_name for handler in clause.hk_state_requirements)
+                if cur_term in terms:
+                    continue
                 # region sweep might not be done, so checking items is likely faster
                 reachable = True
                 for region in clause.hk_region_requirements:
                     if not state.can_reach_region(region, self.player):
                         reachable = False
-                if reachable and state._hk_apply_and_validate_state(
+                if reachable:
+                    terms.add(cur_term)
+                    if state._hk_apply_and_validate_state(
                         clause,
                         self.parent_region,
                         target_region=self.connected_region):
-                    valid_clauses = True
+                        valid_clauses = True
 
         return valid_clauses
 
@@ -201,9 +208,8 @@ class HKRegion(Region):
     def can_reach(self, state) -> bool:
         if self in state.reachable_regions[self.player]:
             return True
-        if not state.stale[self.player] and not state._hk_stale[self.player]:
-            # if the cache is updated we can use the cache
-            return super().can_reach(state)
-        if state._hk_stale[self.player]:
+        elif state._hk_stale[self.player]:
             state._hk_sweep(self.player)
-        return super().can_reach(state)
+            return self in state.reachable_regions[self.player]
+        else:
+            return False

--- a/worlds/hk/classes.py
+++ b/worlds/hk/classes.py
@@ -183,7 +183,7 @@ class HKEntrance(Entrance):
         for index, clause in enumerate(self.hk_rule):
             if cache[index] or state.has_all_counts(clause.hk_item_requirements, self.player):
                 cache[index] = True
-                cur_term = '; '.join(handler.term_name for handler in clause.hk_state_requirements)
+                cur_term = "; ".join(handler.term_name for handler in clause.hk_state_requirements)
                 if cur_term in terms:
                     continue
                 # region sweep might not be done, so checking items is likely faster

--- a/worlds/hk/classes.py
+++ b/worlds/hk/classes.py
@@ -186,11 +186,14 @@ class HKEntrance(Entrance):
                 for region in clause.hk_region_requirements:
                     if not state.can_reach_region(region, self.player):
                         reachable = False
+                target = self.connected_region
                 if reachable and state._hk_apply_and_validate_state(
                         clause,
                         self.parent_region,
-                        target_region=self.connected_region):
+                        target_region=target):
                     valid_clauses = True
+                    # if target is not None and state._hk_per_player_resource_states[target.player][target.name]==[0]:
+                    #     break
 
         return valid_clauses
 

--- a/worlds/hk/classes.py
+++ b/worlds/hk/classes.py
@@ -186,14 +186,11 @@ class HKEntrance(Entrance):
                 for region in clause.hk_region_requirements:
                     if not state.can_reach_region(region, self.player):
                         reachable = False
-                target = self.connected_region
                 if reachable and state._hk_apply_and_validate_state(
                         clause,
                         self.parent_region,
-                        target_region=target):
+                        target_region=self.connected_region):
                     valid_clauses = True
-                    # if target is not None and state._hk_per_player_resource_states[target.player][target.name]==[0]:
-                    #     break
 
         return valid_clauses
 

--- a/worlds/hk/resource_state_vars/__init__.py
+++ b/worlds/hk/resource_state_vars/__init__.py
@@ -3,12 +3,97 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from collections.abc import Generator
 from typing import ClassVar
+from ..charms import charm_name_to_id, charm_names
 
 from BaseClasses import CollectionState
 
+class ResourceState:
+    maxValues=[]
+
+
+
+attribute_list = [] # list of (state part name, number of bits used)
+for charm in charm_names:
+    charm_name = "_".join(charm.split(" "))
+    attribute_list.append((f"CHARM{charm_name_to_id[charm_name] + 1}", 1))
+    attribute_list.append((f"noCHARM{charm_name_to_id[charm_name] + 1}", 1))
+attribute_list += [
+    ("BROKEHEART", 1),
+    ("BROKEGREED", 1),
+    ("BROKESTRENGTH", 1),
+    ("NOFLOWER", 1),
+    ("NOPASSEDCHARMEQUIP", 1),
+    ("OVERCHARMED", 1),
+    ("CANNOTOVERCHARM", 1),
+    ("USEDSHADE", 1),
+    ("CANNOTSHADESKIP", 1),
+    ("SPENTALLSOUL", 1),
+    ("CANNOTREGAINSOUL", 1),
+    ("USEDNOTCHES", 5),
+    ("MAXNOTCHCOST", 5),
+    ("REQUIREDMAXSOUL", 7),
+    ("SOULLIMITER", 7),
+    ("SPENTSOUL", 7),
+    ("SPENTRESERVESOUL", 8),
+    ("SPENTHP", 7),
+    ("SPENTBLUEHP", 7),
+    ("LAZYSPENTHP", 7)
+]
+bit_length_prefix_sums = [0]
+attribute_ids = {}
+top_bits_mask = 0
+for i in range(len(attribute_list)):
+    top_bits_mask += 1 << (bit_length_prefix_sums[-1] + attribute_list[i][1])
+    bit_length_prefix_sums.append(bit_length_prefix_sums[-1] + attribute_list[i][1] + 1)
+    attribute_ids[attribute_list[i][0]] = i
+end_mask = (1 << bit_length_prefix_sums[-1]) - 1
+def rs_add_value(cur_state: int, attr: str, value: int) -> int:
+    attr_id = attribute_ids[attr]
+    return cur_state + (value << bit_length_prefix_sums[attr_id])
+def rs_get_value(cur_state: int, attr: str) -> int:
+    attr_id = attribute_ids[attr]
+    attr_len = attribute_list[attr_id][1]
+    return (cur_state >> bit_length_prefix_sums[attr_id]) & ((1 << attr_len) - 1)
+def rs_set_value(cur_state: int, attr: str, value: int) -> int:
+    attr_id = attribute_ids[attr]
+    attr_len = attribute_list[attr_id][1]
+    start_pos = bit_length_prefix_sums[attr_id]
+    cur_value = (cur_state >> start_pos) & ((1 << attr_len) - 1)
+    return cur_state + ((value - cur_value) << start_pos)
+def rs_increase_if_lower(cur_state: int, attr: str, value: int) -> int:
+    attr_id = attribute_ids[attr]
+    attr_len = attribute_list[attr_id][1]
+    pos = bit_length_prefix_sums[attr_id]
+    cur_value = (cur_state >> pos) & ((1 << attr_len) - 1)
+    if cur_value < value:
+        return cur_state + ((value - cur_value) << pos)
+    else:
+        return cur_state
+def rs_subtract_at_most(cur_state: int, attr: str, value: int) -> int:
+    attr_id = attribute_ids[attr]
+    attr_len = attribute_list[attr_id][1]
+    pos = bit_length_prefix_sums[attr_id]
+    cur_value = (cur_state >> pos) & ((1 << attr_len) - 1)
+    return cur_state - (min(cur_value, value) << pos)
+def rs_leq(state1: int, state2: int) -> bool:
+    return ((state1 + end_mask - state2) & top_bits_mask) == top_bits_mask
+def dict_to_rs(inp: dict[str,int]) -> int:
+    res = 0
+    for key in inp:
+        res = rs_add_value(res, key, inp[key])
+    return res
+def rs_to_dict(inp: int) -> dict[str,int]:
+    res = {}
+    for index in range(len(attribute_list)):
+        cur_key = attribute_list[index][0]
+        cur_value = rs_get_value(inp, cur_key)
+        if cur_value:
+            res[cur_key] = cur_value
+    return res
 # For ease of typing in submodules
 cs = CollectionState
-rs = Counter
+rs = int
+
 
 
 class ResourceStateHandler(type):

--- a/worlds/hk/resource_state_vars/__init__.py
+++ b/worlds/hk/resource_state_vars/__init__.py
@@ -120,11 +120,12 @@ class ResourceStateHandler(type):
 class RCStateVariable(metaclass=ResourceStateHandler):
     prefix: str
     player: int
+    term_name: str
 
     def __init__(self, term: str, player: int):
         assert term.startswith(self.prefix)
         self.player = player
-
+        self.term_name = term
         # expecting "prefix" or "prefix[one,two,three]"
         if term != self.prefix:
             params = term[len(self.prefix)+1:-1].split(",")

--- a/worlds/hk/resource_state_vars/__init__.py
+++ b/worlds/hk/resource_state_vars/__init__.py
@@ -7,10 +7,6 @@ from ..charms import charm_name_to_id, charm_names
 
 from BaseClasses import CollectionState
 
-class ResourceState:
-    maxValues=[]
-
-
 
 attribute_list = [] # list of (state part name, number of bits used)
 for charm in charm_names:

--- a/worlds/hk/resource_state_vars/cast_spell.py
+++ b/worlds/hk/resource_state_vars/cast_spell.py
@@ -65,28 +65,30 @@ class CastSpellVariable(RCStateVariable):
 
     def modify_state(self, state_blob: rs, item_state: cs) -> Generator[rs]:
         if self.nearby_soul_to_bool(item_state, self.before_soul):
-            self.sp_manager.try_restore_all_soul(state_blob, item_state, True)
+            _, state_blob = self.sp_manager.try_restore_all_soul(state_blob, item_state, True)
         if not self.equip_st.is_determined(state_blob, item_state):
-            state24 = state_blob.copy()
-            if self.equip_st.try_equip(state24, item_state):
-                state33 = state_blob.copy()
-                self.equip_st.set_unequippable(state33)
-                if self.try_cast(state24, item_state, 24):
+            st_equipped, state24 = self.equip_st.try_equip(state_blob, item_state)
+            if st_equipped:
+                state33 = self.equip_st.set_unequippable(state_blob)
+                casted24, state24 = self.try_cast(state24, item_state, 24)
+                if casted24:
                     yield state24
-                    if self.try_cast(state33, item_state, 33):
+                    casted33, state33 = self.try_cast(state33, item_state, 33)
+                    if casted33:
                         yield state33
             else:
-                state33 = state_blob.copy()
-                self.equip_st.set_unequippable(state33)
-                if self.try_cast(state33, item_state, 33):
+                state33 = self.equip_st.set_unequippable(state_blob)
+                casted33, state33 = self.try_cast(state33, item_state, 33)
+                if casted33:
                     yield state33
         else:
-            ret = state_blob.copy()
-            if self.equip_st.is_equipped(ret):
-                if self.try_cast(ret, item_state, 24):
+            if self.equip_st.is_equipped(state_blob):
+                casted24, ret = self.try_cast(state_blob, item_state, 24)
+                if casted24:
                     yield ret
             else:
-                if self.try_cast(ret, item_state, 33):
+                casted33, ret = self.try_cast(state_blob, item_state, 33)
+                if casted33:
                     yield ret
 
     def nearby_soul_to_bool(self, item_state: cs, soul: NearbySoul) -> bool:
@@ -98,13 +100,14 @@ class CastSpellVariable(RCStateVariable):
     def get_mode(self, item_state: cs) -> NearbySoul:
         return item_state._hk_soul_modes[self.player]
 
-    def try_cast(self, state_blob: rs, item_state: cs, amount_per_cast) -> bool:
-        if not self.sp_manager.try_spend_soul_sequence(state_blob, item_state, amount_per_cast, self.casts):
-            return False
+    def try_cast(self, state_blob: rs, item_state: cs, amount_per_cast) -> tuple[bool, rs]:
+        soul_spent, new_state = self.sp_manager.try_spend_soul_sequence(state_blob, item_state, amount_per_cast, self.casts)
+        if not soul_spent:
+            return False, state_blob
         if self.nearby_soul_to_bool(item_state, self.after_soul):
-            self.sp_manager.try_resore_soul(state_blob, item_state, sum(self.casts) * 33)
+            new_state = self.sp_manager.try_restore_soul(new_state, item_state, sum(self.casts) * 33)
             # recover the same amount of soul in all paths to respect the state ordering
-        return True
+        return True, new_state
 
 
 class ShriekPogoVariable(CastSpellVariable):

--- a/worlds/hk/resource_state_vars/direct_compare.py
+++ b/worlds/hk/resource_state_vars/direct_compare.py
@@ -1,5 +1,5 @@
 from ..options import HKOptions
-from . import RCStateVariable, cs, rs
+from . import RCStateVariable, cs, rs, rs_get_value
 
 
 class DirectCompare:
@@ -30,11 +30,11 @@ class EQVariable(DirectCompare, RCStateVariable):
 
     def _modify_state(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         if self.value.isdigit():
-            return state_blob[self.term] == int(self.value), state_blob
+            return rs_get_value(state_blob, self.term) == int(self.value), state_blob
         else:  # noqa: RET505
             v = self.value == "TRUE"
             assert v or self.value == "FALSE"
-            return state_blob[self.term] == v, state_blob
+            return rs_get_value(state_blob, self.term) == v, state_blob
 
 
 class GTVariable(DirectCompare, RCStateVariable):
@@ -44,7 +44,7 @@ class GTVariable(DirectCompare, RCStateVariable):
 
     def _modify_state(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         assert self.value.isdigit()
-        return state_blob[self.term] > int(self.value), state_blob
+        return rs_get_value(state_blob, self.term) > int(self.value), state_blob
 
 
 class LTVariable(DirectCompare, RCStateVariable):
@@ -54,4 +54,4 @@ class LTVariable(DirectCompare, RCStateVariable):
 
     def _modify_state(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         assert self.value.isdigit()
-        return state_blob[self.term] < int(self.value), state_blob
+        return rs_get_value(state_blob, self.term) < int(self.value), state_blob

--- a/worlds/hk/resource_state_vars/equip_charm.py
+++ b/worlds/hk/resource_state_vars/equip_charm.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 
 from ..charms import charm_name_to_id, charm_names
 from ..options import HKOptions
-from . import RCStateVariable, cs, rs
+from . import RCStateVariable, cs, rs, rs_add_value, rs_set_value, rs_increase_if_lower, rs_get_value
 
 
 class EquipResult(IntEnum):
@@ -74,24 +74,22 @@ class EquipCharmVariable(RCStateVariable):
         # return bool(item_state._hk_processed_item_cache[self.player][self.charm_name])
 
     def _modify_state(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
-        return self.try_equip(state_blob, item_state), state_blob
+        return self.try_equip(state_blob, item_state)
 
     def _try_equip(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         if self.is_equipped(state_blob):
             return True, state_blob
         if self.can_equip(state_blob, item_state) != EquipResult.NONE:
-            ret = state_blob.copy()
-            self.do_equip_charm(ret, item_state)
+            ret = self.do_equip_charm(state_blob, item_state)
             return True, ret
         return False, state_blob
 
-    def try_equip(self, state_blob: rs, item_state: cs) -> bool:
+    def try_equip(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         if self.is_equipped(state_blob):
-            return True
+            return True, state_blob
         if self.can_equip(state_blob, item_state) != EquipResult.NONE:
-            self.do_equip_charm(state_blob, item_state)
-            return True
-        return False
+            return True, self.do_equip_charm(state_blob, item_state)
+        return False, state_blob
 
     @property
     def anti_term(self) -> str:
@@ -102,7 +100,7 @@ class EquipCharmVariable(RCStateVariable):
         return f"{self.equip_prefix}{self.charm_id}"
 
     def has_state_requirements(self, state_blob: rs, item_state: cs) -> bool:
-        if state_blob["NOPASSEDCHARMEQUIP"] or state_blob[self.anti_term]:
+        if rs_get_value(state_blob, "NOPASSEDCHARMEQUIP") or rs_get_value(state_blob, self.anti_term):
             return False
         return True
 
@@ -115,14 +113,14 @@ class EquipCharmVariable(RCStateVariable):
     def has_notch_requirments(self, state_blob: rs, item_state: cs) -> EquipResult:
         notch_cost = self.get_notch_cost(item_state)
         if notch_cost <= 0 or self.is_equipped(state_blob):
-            return EquipResult.OVERCHARM if state_blob["OVERCHARMED"] else EquipResult.NONOVERCHARM
-        # can be equipped
-        net_notches = self.get_total_notches(item_state) - state_blob["USEDNOTCHES"] - notch_cost
+            return EquipResult.OVERCHARM if rs_get_value(state_blob, "OVERCHARMED") else EquipResult.NONOVERCHARM
+        # can be equipped, max 20 total notches used if lots of notches are in starting inventory to not overflow
+        net_notches = min(20, self.get_total_notches(item_state)) - rs_get_value(state_blob, "USEDNOTCHES") - notch_cost
         if net_notches >= 0:
             return EquipResult.NONOVERCHARM
         # something to figure out if you can overcharm to get this on
-        overcharm_save = max(notch_cost, state_blob["MAXNOTCHCOST"])
-        if net_notches + overcharm_save > 0 and not state_blob["CANNOTOVERCHARM"]:
+        overcharm_save = max(notch_cost, rs_get_value(state_blob, "MAXNOTCHCOST"))
+        if net_notches + overcharm_save > 0 and not rs_get_value(state_blob, "CANNOTOVERCHARM"):
             return EquipResult.OVERCHARM
         return EquipResult.NONE  # TODO doublecheck
 
@@ -139,24 +137,25 @@ class EquipCharmVariable(RCStateVariable):
             return EquipResult.NONE
         return self.has_notch_requirments(state_blob, item_state)
 
-    def do_equip_charm(self, state_blob: rs, item_state: cs) -> None:
+    def do_equip_charm(self, state_blob: rs, item_state: cs) -> rs:
         notch_cost = self.get_notch_cost(item_state)
-        state_blob["USEDNOTCHES"] += notch_cost
-        # one of these 2 should probably go at some point
-        state_blob[self.term] = True
-        state_blob[self.charm_key] = True
-        state_blob["MAXNOTCHCOST"] = max(state_blob["MAXNOTCHCOST"], notch_cost)
-        if state_blob["USEDNOTCHES"] > item_state.count("NOTCHES", self.player):
-            state_blob["OVERCHARMED"] = True
+        state_blob = rs_add_value(state_blob, "USEDNOTCHES", notch_cost)
+        state_blob = rs_set_value(state_blob, self.term, 1)
+        # doesn't seem to be used for anything and supporting it would unnecessarily increase the state size
+        # state_blob[self.charm_key] = True
+        state_blob = rs_increase_if_lower(state_blob, "MAXNOTCHCOST", notch_cost)
+        if rs_get_value(state_blob, "USEDNOTCHES") > item_state.count("NOTCHES", self.player):
+            state_blob = rs_set_value(state_blob, "OVERCHARMED", 1)
+        return state_blob
 
     def is_equipped(self, state_blob: rs) -> bool:
-        return bool(state_blob[self.term])
+        return bool(rs_get_value(state_blob, self.term))
 
-    def set_unequippable(self, state_blob: rs) -> None:
-        state_blob[self.anti_term] = True
+    def set_unequippable(self, state_blob: rs) -> rs:
+        return rs_set_value(state_blob, self.anti_term, 1)
 
     def get_avaliable_notches(self, state_blob: rs, item_state: cs) -> int:
-        return item_state.count("NOTCHES", self.player) - state_blob["USEDNOTCHES"]
+        return item_state.count("NOTCHES", self.player) - rs_get_value(state_blob, "USEDNOTCHES")
 
     def can_exclude(self, options: HKOptions) -> bool:
         return False
@@ -165,7 +164,7 @@ class EquipCharmVariable(RCStateVariable):
         items[self.charm_key] = 1
 
     def is_determined(self, state_blob: rs, item_state: cs) -> bool:
-        return state_blob[self.term] or state_blob[self.anti_term]
+        return bool(rs_get_value(state_blob, self.term)) or bool(rs_get_value(state_blob, self.anti_term))
 
     def has_charm_progression(self, item_state: cs) -> bool:
         return self.has_item(item_state)
@@ -177,7 +176,7 @@ class EquipCharmVariable(RCStateVariable):
             charm_list: Iterable[EquipCharmVariable],
     ) -> Generator[rs]:
         charms = []
-        base_state = state_blob.copy()
+        base_state = state_blob
         for c in charm_list:
             if not c.is_determined(base_state, item_state):
                 if (
@@ -185,7 +184,7 @@ class EquipCharmVariable(RCStateVariable):
                     or not c.has_state_requirements(base_state, item_state)
                     or not c.has_notch_requirments(base_state, item_state)
                 ):
-                    c.set_unequippable(base_state)
+                    base_state = c.set_unequippable(base_state)
                 else:
                     charms.append(c)
 
@@ -198,15 +197,18 @@ class EquipCharmVariable(RCStateVariable):
 
         p = 1 << charm_len
         for i in range(p):
-            cur_state = base_state.copy()
+            cur_state = base_state
             for j in range(charm_len):
                 f = 1 << j
                 if (i & f) == f:  # equip
-                    if not charms[j].try_equip(cur_state, item_state):
+                    equipped, new_state = charms[j].try_equip(cur_state, item_state)
+                    if not equipped:
                         # should only fail due to out of notches
                         break
+                    else:
+                        cur_state = new_state
                 else:  # do not equip
-                    charms[j].set_unequippable(cur_state)
+                    cur_state = charms[j].set_unequippable(cur_state)
             else:
                 # only yield if we did not break
                 yield cur_state
@@ -230,21 +232,21 @@ class FragileCharmVariable(EquipCharmVariable):
     def terms(self) -> list[str]:
         return [*super().terms, "Can_Repair_Fragile_Charms"]
 
-    def break_charm(self, state_blob: rs, item_state: cs) -> None:
+    def break_charm(self, state_blob: rs, item_state: cs) -> rs:
         if item_state.has(self.charm_key, self.player, 2):
-            return
-        if state_blob[self.term]:
-            state_blob[self.term] = 0
-            state_blob["USEDNOTCHES"] -= self.get_notch_cost(item_state)
-            if state_blob["OVERCHARMED"]:
-                state_blob["OVERCHARMED"] = 0
-            state_blob[self.anti_term] = 1
-            state_blob[self.break_term] = 1
+            return state_blob
+        if rs_get_value(state_blob, self.term):
+            state_blob = rs_add_value(state_blob, self.term, -1)
+            state_blob = rs_add_value(state_blob, "USEDNOTCHES", -self.get_notch_cost(item_state))
+            state_blob = rs_set_value(state_blob, "OVERCHARMED", 0)
+            state_blob = rs_set_value(state_blob, self.anti_term, 1)
+            state_blob = rs_set_value(state_blob, self.break_term, 1)
+        return state_blob
 
     def has_state_requirements(self, state_blob: rs, item_state: cs) -> bool:
         return (super().has_state_requirements(state_blob, item_state)
                 and ((self.has_unbreakable_item(item_state))
-                     or (not state_blob[self.break_term] and item_state.has("Can_Repair_Fragile_Charms", self.player))))
+                     or (not rs_get_value(state_blob, self.break_term) and item_state.has("Can_Repair_Fragile_Charms", self.player))))
 
     @classmethod
     def try_match(cls, term: str) -> bool:

--- a/worlds/hk/resource_state_vars/equip_charm.py
+++ b/worlds/hk/resource_state_vars/equip_charm.py
@@ -279,6 +279,10 @@ class WhiteFragmentEquipVariable(EquipCharmVariable):
         if self.charm_name == "Void_Heart":
             self.quantity = 3
 
+    @property
+    def terms(self) -> list[str]:
+        return ["WHITEFRAGMENT", "NOTCHES"]
+
     @classmethod
     def try_match(cls, term: str) -> bool:
         if term.startswith(cls.prefix):

--- a/worlds/hk/resource_state_vars/flower_provider.py
+++ b/worlds/hk/resource_state_vars/flower_provider.py
@@ -1,5 +1,5 @@
 from ..options import HKOptions
-from . import RCStateVariable, cs, rs
+from . import RCStateVariable, cs, rs, rs_set_value
 
 
 class FlowerProviderVariable(RCStateVariable):
@@ -10,8 +10,7 @@ class FlowerProviderVariable(RCStateVariable):
     #     return (term for term in ("VessleFragments",))
 
     def _modify_state(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
-        state_blob["NOFLOWER"] = False
-        return True, state_blob
+        return True, rs_set_value(state_blob, "NOFLOWER", 0)
 
     @classmethod
     def try_match(cls, term: str) -> bool:

--- a/worlds/hk/resource_state_vars/health_manager.py
+++ b/worlds/hk/resource_state_vars/health_manager.py
@@ -2,7 +2,7 @@ from collections import Counter
 from collections.abc import Generator, Iterable
 from typing import NamedTuple
 
-from . import ResourceStateHandler, cs, rs
+from . import ResourceStateHandler, cs, rs, rs_add_value, rs_get_value, rs_set_value, rs_subtract_at_most
 from .equip_charm import EquipCharmVariable, FragileCharmVariable
 from .soul_manager import SoulManager
 
@@ -102,60 +102,50 @@ class HealthManager(metaclass=ResourceStateHandler):
             for ret in rets:
                 yield next(self.give_blue_health(ret, item_state, amount))
         else:
-            ret = state_blob.copy()
-            ret["SPENTBLUEHP"] -= amount
-            yield ret
+            yield rs_add_value(state_blob, "SPENTBLUEHP", -amount)
 
     def give_health(self, state_blob: rs, item_state: cs, amount: int) -> Generator[rs]:
         if not self.is_hp_determined(state_blob):
-            if state_blob["LAZYSPENTHP"] > 0:
+            if rs_get_value(state_blob, "LAZYSPENTHP") > 0:
                 rets = self.determine_hp(state_blob, item_state)
                 for ret in rets:
                     yield next(self.give_health(ret, item_state, amount))
             else:
                 yield state_blob
         else:
-            ret = state_blob.copy()
-            ret["SPENTHP"] = max(0, ret["SPENTHP"] - amount)
-            yield ret
+            yield rs_subtract_at_most(state_blob, "SPENTHP", amount)
 
     def restore_white_health(self, state_blob: rs, item_state: cs) -> Generator[rs]:
         if not self.is_hp_determined(state_blob):
-            if state_blob["LAZYSPENTHP"] == 0:
+            if rs_get_value(state_blob, "LAZYSPENTHP") == 0:
                 yield state_blob
             else:
                 rets = self.determine_hp(state_blob, item_state)
                 for ret in rets:
                     yield next(self.restore_white_health(ret, item_state))
         else:
-            ret = state_blob.copy()
-            ret["SPENTHP"] = 0
-            yield ret
+            yield rs_set_value(state_blob, "SPENTHP", 0)
 
     def restore_all_health(self, state_blob: rs, item_state: cs) -> Generator[rs]:
         if not self.is_hp_determined(state_blob):
-            ret = state_blob.copy()
-            ret["LAZYSPENTHP"] = 0
-            yield ret
+            yield rs_set_value(state_blob, "LAZYSPENTHP", 0)
         else:
-            ret = state_blob.copy()
-            ret["SPENTHP"] = 0
-            ret["SPENTBLUEHP"] = 0
-            yield ret
+            ret = rs_set_value(state_blob, "SPENTHP", 0)
+            yield rs_set_value(ret, "SPENTBLUEHP", 0)
 
-    def try_focus(self, state_blob: rs, item_state: cs) -> bool:
+    def try_focus(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         if not item_state.has("FOCUS", self.player) or not self.is_hp_determined(state_blob):
-            return False
+            return False, state_blob
         for charm in self.focus_charms:
             if not charm.is_determined(state_blob, item_state):
-                return False
+                return False, state_blob
         if not self.ssm.try_spend_soul(state_blob, item_state, 33):
-            return False
+            return False, state_blob
         heal_amount = self.get_heal_amount(state_blob, item_state)
 
-        if state_blob["SPENTHP"] > 0:
-            state_blob["SPENTHP"] = max(0, state_blob["SPENTHP"] - heal_amount)
-        return True
+        if rs_get_value(state_blob, "SPENTHP") > 0:
+            state_blob = rs_subtract_at_most(state_blob, "SPENTHP", heal_amount)
+        return True, state_blob
 
     def do_focus(self, state_blob: rs, item_state: cs, amount: int) -> Generator[rs]:
         if not item_state.has("FOCUS", self.player):
@@ -169,14 +159,12 @@ class HealthManager(metaclass=ResourceStateHandler):
             for r in rets:
                 yield from self.do_focus(r, item_state, amount)
             return
-        if not self.ssm.try_spend_soul(state_blob, item_state, 33):
+        spent_soul, state_blob = self.ssm.try_spend_soul(state_blob, item_state, 33)
+        if not spent_soul:
             return
 
-        ret = state_blob.copy()
-        spent_hp = ret["SPENTHP"]
-        heal_amount = self.get_heal_amount(ret, item_state)
-        ret["SPENTHP"] = max(0, spent_hp - amount * heal_amount)
-        yield ret
+        heal_amount = self.get_heal_amount(state_blob, item_state)
+        yield rs_subtract_at_most(state_blob, "SPENTHP", amount * heal_amount)
 
     def get_heal_amount(self, state_blob: rs, item_state: cs) -> int:
         if self.jonis.is_equipped(state_blob):
@@ -185,17 +173,16 @@ class HealthManager(metaclass=ResourceStateHandler):
             return 2
         return 1
 
-    def is_hp_determined(self, state_blob: rs) -> Generator[rs]:
-        return state_blob["LAZYSPENTHP"] == self.max_damage
+    def is_hp_determined(self, state_blob: rs) -> bool:
+        return rs_get_value(state_blob, "LAZYSPENTHP") == self.max_damage
 
     def determine_hp(self, state_blob: rs, item_state: cs) -> Generator[rs]:
         if self.is_hp_determined(state_blob):
             yield state_blob
             return
 
-        ret_base = state_blob.copy()
-        lazy_spent_hp = ret_base["LAZYSPENTHP"]
-        ret_base["LAZYSPENTHP"] = self.max_damage
+        ret_base = rs_set_value(state_blob, "LAZYSPENTHP", self.max_damage)
+        lazy_spent_hp = rs_get_value(state_blob, "LAZYSPENTHP")
 
         rets = []
         for s in self.decide_overcharm(ret_base, item_state):
@@ -206,15 +193,11 @@ class HealthManager(metaclass=ResourceStateHandler):
         yield from rets
 
     def decide_overcharm(self, state_blob: rs, item_state: cs) -> Generator[rs]:
-        if state_blob["CANNOTOVERCHARM"] or state_blob["OVERCHARMED"]:
+        if rs_get_value(state_blob, "CANNOTOVERCHARM") or rs_get_value(state_blob, "OVERCHARMED"):
             yield state_blob
         else:
-            oc = state_blob.copy()
-            oc["OVERCHARMED"] = 1
-            yield oc
-            noc = state_blob.copy()
-            noc["CANNOTOVERCHARM"] = 1
-            yield noc
+            yield rs_set_value(state_blob, "OVERCHARMED", 1)
+            yield rs_set_value(state_blob, "CANNOTOVERCHARM", 1)
 
     def get_hp_info(self, state_blob: rs, item_state: cs) -> HPInfo:
         if not self.is_hp_determined(state_blob):
@@ -224,26 +207,26 @@ class HealthManager(metaclass=ResourceStateHandler):
             max_hp += 2
         if self.jonis.is_equipped(state_blob):
             max_hp = int(1.4 * max_hp)
-        hp = max_hp - state_blob["SPENTHP"]
-        blue_hp = -state_blob["SPENTBLUEHP"]
+        hp = max_hp - rs_get_value(state_blob, "SPENTHP")
+        blue_hp = -rs_get_value(state_blob, "SPENTBLUEHP")
         if self.lb_heart.is_equipped(state_blob):
             blue_hp += 2
         if self.lb_core.is_equipped(state_blob):
             blue_hp += 4
         return HPInfo(hp, blue_hp, max_hp)
 
-    def do_hit(self, state_blob: rs, item_state: cs, hit: HitInfo) -> Counter:
+    def do_hit(self, state_blob: rs, item_state: cs, hit: HitInfo) -> rs:
         if not hit.survives:
             raise Exception("do_hit on lethal damage")
-        ret = state_blob.copy()
+        ret = state_blob
         if hit.blue_hp_damage:
-            ret["SPENTBLUEHP"] += hit.blue_hp_damage
+            ret = rs_add_value(ret, "SPENTBLUEHP", hit.blue_hp_damage)
         if hit.white_hp_damage:
-            ret["SPENTHP"] += hit.white_hp_damage
+            ret = rs_add_value(ret, "SPENTHP", hit.white_hp_damage)
         if hit.wait_after_hit:
             if hit.white_hp_damage > 0 and self.hiveblood.is_equipped(ret):
-                ret["SPENTHP"] -= 1
-        ret["NOFLOWER"] = 1
+                ret = rs_add_value(ret, "SPENTHP", -1)
+        ret = rs_set_value(ret, "NOFLOWER", 1)
         return ret
 
     def take_damage(self, state_blob: rs, item_state: cs, amount: int) -> Generator[rs]:
@@ -253,39 +236,38 @@ class HealthManager(metaclass=ResourceStateHandler):
                     yield from self.take_damage_strict(r, item_state, amount, True)
                 return
             else:
-                ret = state_blob.copy()
-                ret["LAZYSPENTHP"] += 1
-                yield ret
+                yield rs_add_value(state_blob, "LAZYSPENTHP", 1)
         else:
             yield from self.take_damage_strict(state_blob, item_state, amount, True)
 
     def take_damage_sequence(self, state_blob: rs, item_state: cs, amounts: Iterable[int]) -> Generator[rs]:
         if not self.is_hp_determined(state_blob):
             for r in self.determine_hp(state_blob, item_state):
-                yield self.take_damage_sequence(r, item_state, amounts)
+                yield from self.take_damage_sequence(r, item_state, amounts)
             return
 
-        rets = [state_blob.copy()]
+        rets = [state_blob]
         for i, amount in enumerate(amounts):
             wait_after_hit = i == len(amounts) - 1
+            # I'm assuming that you should look at every option currently in rets to take damage instead of looking at state_blob
+            # but this method doesn't seem to be used anywhere so I won't be worrying about it currently
             rets = list(self.take_damage_strict(state_blob, item_state, amount, wait_after_hit))
         for r in rets:
             yield r
 
     def can_take_next_lazy_hit(self, state_blob: rs, item_state: cs) -> bool:
-        hits_taken = state_blob["LAZYSPENTHP"]
+        hits_taken = rs_get_value(state_blob, "LAZYSPENTHP")
         max_hp = item_state.count("MASKSHARDS", self.player) // 4
         total_hits = (max_hp - 1) // 2
         return total_hits - hits_taken > 0
 
     def take_damage_strict(self, state_blob: rs, item_state: cs, amount: int, wait_after_hit: bool) -> Generator[rs]:
-        adj_amount = 2 * amount if state_blob["OVERCHARMED"] else amount
+        adj_amount = 2 * amount if rs_get_value(state_blob, "OVERCHARMED") else amount
 
         info = self.get_hp_info(state_blob, item_state)
         hit = HitInfo(info, adj_amount, wait_after_hit)
         if hit.survives:
-            ret = state_blob.copy()
-            yield self.do_hit(ret, item_state, hit)
+            yield self.do_hit(state_blob, item_state, hit)
             return
         # else
         rets = list(EquipCharmVariable.generate_charm_combinations(state_blob, item_state, self.before_death_charms))
@@ -293,7 +275,7 @@ class HealthManager(metaclass=ResourceStateHandler):
             yield from self.take_damage_desperate(state_blob, item_state, amount, True)
 
     def take_damage_desperate(self, state_blob: rs, item_state: cs, amount: int, wait_after_hit: bool) -> Generator[rs]:
-        adj_amount = 2 * amount if state_blob["OVERCHARMED"] else amount
+        adj_amount = 2 * amount if rs_get_value(state_blob, "OVERCHARMED") else amount
         info = self.get_hp_info(state_blob, item_state)
 
         deficit = adj_amount - info.current_white_hp
@@ -308,7 +290,7 @@ class HealthManager(metaclass=ResourceStateHandler):
             else:
                 return
         else:
-            rets = [state_blob.copy()]
+            rets = [state_blob]
 
         for r in rets:
             info = self.get_hp_info(r, item_state)

--- a/worlds/hk/resource_state_vars/regain_soul.py
+++ b/worlds/hk/resource_state_vars/regain_soul.py
@@ -1,5 +1,5 @@
 from ..options import HKOptions
-from . import RCStateVariable, cs, rs
+from . import RCStateVariable, cs, rs, rs_get_value, rs_set_value, rs_add_value, rs_subtract_at_most
 
 
 class RegainSoulVariable(RCStateVariable):
@@ -21,31 +21,27 @@ class RegainSoulVariable(RCStateVariable):
     #     return (term for term in ("VessleFragments",))
 
     def _modify_state(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
-        if state_blob["CANNOTREGAINSOUL"]:
+        if rs_get_value(state_blob, "CANNOTREGAINSOUL"):
             return False, state_blob
-        if state_blob["SPENTALLSOUL"]:
-            state_blob["SPENTRESERVESOUL"] = self.get_max_reserve_soul(item_state)
-            state_blob["SPENTSOUL"] = self.get_max_soul(state_blob)
-            state_blob["SPENTALLSOUL"] = False
-        soul_diff = self.get_max_soul(state_blob) - state_blob["SPENTSOUL"]  # i simplified this
-        if self.amount < soul_diff:
-            state_blob["SPENTSOUL"] -= self.amount
+        if rs_get_value(state_blob, "SPENTALLSOUL"):
+            state_blob = rs_set_value(state_blob, "SPENTRESERVESOUL", self.get_max_reserve_soul(item_state))
+            state_blob = rs_set_value(state_blob, "SPENTSOUL", self.get_max_soul(state_blob))
+            state_blob = rs_set_value(state_blob, "SPENTALLSOUL", 0)
+        # rewritten to be actually correct (might be for no reason since it's currently unused, idk)
+        spent_soul = rs_get_value(state_blob, "SPENTSOUL")
+        if self.amount < spent_soul:
+            state_blob = rs_add_value(state_blob, "SPENTSOUL", -self.amount)
         else:
-            state_blob["SPENTSOUL"] = 0
-            amount = self.amount - soul_diff
-            reserve_diff = (self.get_max_reserve_soul(item_state) - state_blob["SPENTRESERVESOUL"])
-            # i simplified this
-            if amount < reserve_diff:
-                state_blob["SPENTRESERVESOUL"] -= amount
-            else:
-                state_blob["SPENTRESERVESOUL"] = 0
+            state_blob = rs_add_value(state_blob, "SPENTSOUL", -spent_soul)
+            amount = self.amount - spent_soul
+            state_blob = rs_subtract_at_most(state_blob, "SPENTRESERVESOUL", amount)
         return True, state_blob
 
     def get_max_reserve_soul(self, item_state: cs) -> int:
         return (item_state.count("VesselFragment", self.player) // 3) * 33
 
     def get_max_soul(self, state_blob: rs) -> int:
-        return 99 - state_blob["SOULLIMITER"]
+        return 99 - rs_get_value(state_blob, "SOULLIMITER")
 
     def can_exclude(self, options: HKOptions) -> bool:
         return False

--- a/worlds/hk/resource_state_vars/resetter.py
+++ b/worlds/hk/resource_state_vars/resetter.py
@@ -2,7 +2,7 @@ from typing import Any, ClassVar
 
 from ..options import HKOptions
 from ..state_mixin import default_state
-from . import RCStateVariable, cs, rs
+from . import RCStateVariable, cs, rs, rs_set_value, rs_get_value
 
 
 class RCResetter:
@@ -27,17 +27,16 @@ class RCResetter:
                 if value != "None":
                     # if the reset logic evaluates to True, update to new value
                     if key not in self.reset_state:
-                        if key in state_blob:
-                            del state_blob[key]
+                        state_blob = rs_set_value(state_blob, key, 0)
                     else:
-                        state_blob[key] = self.reset_state[key]
+                        state_blob = rs_set_value(state_blob, key, self.reset_state[key])
             return True, state_blob
         else:  # noqa: RET505
             ret = default_state(defaults=self.reset_state)
             for key, value in self.reset_properties.items():
                 if value == "None":  # TODO: fix
                     # if the reset logic evaluates to False keep old value
-                    ret[key] = state_blob[key]
+                    ret = rs_set_value(ret, key, rs_get_value(state_blob, key))
             return True, ret
 
     @classmethod
@@ -54,8 +53,8 @@ class RCResetter:
 
 class BenchResetVariable(RCResetter, RCStateVariable):
     prefix: str = "$BENCHRESET"
-    reset_state: ClassVar[dict[str, str]] = {
-        "NOPASSEDCHARMEQUIP": False
+    reset_state: ClassVar[dict[str, int]] = {
+        "NOPASSEDCHARMEQUIP": 0
     }
     opt_in = False
     reset_properties: ClassVar[dict[str, str]] = {

--- a/worlds/hk/resource_state_vars/shade_state.py
+++ b/worlds/hk/resource_state_vars/shade_state.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 
 from ..options import HKOptions
-from . import RCStateVariable, cs, rs
+from . import RCStateVariable, cs, rs, rs_get_value, rs_add_value, rs_set_value, rs_to_dict
 from .equip_charm import EquipCharmVariable, EquipResult, FragileCharmVariable
 from .soul_manager import SoulManager
 
@@ -42,47 +42,46 @@ class ShadeStateVariable(RCStateVariable):
         return []
 
     def modify_state(self, state_blob: rs, item_state: cs) -> Generator[rs]:
-        ret = state_blob.copy()
-        if self.do_shade_skip(ret, item_state):
+        shade_skipped, ret = self.do_shade_skip(state_blob, item_state)
+        if shade_skipped:
             yield ret
 
-    def do_shade_skip(self, state_blob: rs, item_state: cs) -> bool:
+    def do_shade_skip(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         if self.voidheart.is_equipped(state_blob):
-            return False
-        if state_blob["CANNOTSHADESKIP"] or state_blob["USEDSHADE"]:
-            return False
-        self.voidheart.set_unequippable(state_blob)
-        state_blob["USEDSHADE"] = 1
+            return False, state_blob
+        if rs_get_value(state_blob, "CANNOTSHADESKIP") or rs_get_value(state_blob, "USEDSHADE"):
+            return False, state_blob
+        state_blob = self.voidheart.set_unequippable(state_blob)
+        state_blob = rs_add_value(state_blob, "USEDSHADE", 1)
 
-        test_one = self.sp_manager.try_set_soul_limit(state_blob, item_state, 33, True)
-        test_two = self.sp_manager.try_set_soul_limit(state_blob, item_state, 0, False)
+        test_one, state_blob = self.sp_manager.try_set_soul_limit(state_blob, item_state, 33, True)
+        test_two, state_blob = self.sp_manager.try_set_soul_limit(state_blob, item_state, 0, False)
         if not test_one or not test_two:
             # edge case where using a shade skip is not safe to re-trace the path
-            return False
-        if not self.check_health_requirement(state_blob, item_state):
+            return False, state_blob
+        requirement_checked, state_blob = self.check_health_requirement(state_blob, item_state)
+        if not requirement_checked:
             # checking joni's and fragile heart
-            return False
-        if not state_blob["NOFLOWER"]:
-            state_blob["NOFLOWER"] = 1
-            # just not worth it
-        return True
+            return False, state_blob
+        state_blob = rs_set_value(state_blob, "NOFLOWER", 1) # just not worth it
+        return True, state_blob
 
-    def check_health_requirement(self, state_blob: rs, item_state: cs) -> bool:
+    def check_health_requirement(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         if self.health == 1:
-            return True
+            return True, state_blob
 
         if self.jonis.is_equipped(state_blob):
-            return False
-        self.jonis.set_unequippable(state_blob)
+            return False, state_blob
+        state_blob = self.jonis.set_unequippable(state_blob)
 
         hp = (item_state.count("MASKSHARDS", self.player) // 4) // 2
         if (
             hp >= self.health
             or (self.health == hp + 1 and self.fragile_heart.can_equip(state_blob, item_state) != EquipResult.NONE)
         ):
-            self.fragile_heart.break_charm(state_blob, item_state)
-            return True
-        return False
+            state_blob = self.fragile_heart.break_charm(state_blob, item_state)
+            return True, state_blob
+        return False, state_blob
 
     def can_exclude(self, options: HKOptions) -> bool:
         return not bool(options.ShadeSkips)

--- a/worlds/hk/resource_state_vars/soul_manager.py
+++ b/worlds/hk/resource_state_vars/soul_manager.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 
-from . import ResourceStateHandler, cs, rs
+from . import ResourceStateHandler, cs, rs, rs_get_value, rs_set_value, rs_add_value, rs_increase_if_lower
 
 
 class SoulInfo:
@@ -32,8 +32,8 @@ class SoulManager(metaclass=ResourceStateHandler):
         self.player = player
 
     def spend_soul(self, state_blob: rs, item_state: cs, amount: int) -> Generator[rs]:
-        ret = state_blob.copy()
-        if self.try_spend_soul(ret, item_state, amount):
+        spent, ret = self.try_spend_soul(state_blob, item_state, amount)
+        if spent:
             yield ret
 
     def spend_soul_sequence(self):
@@ -42,38 +42,41 @@ class SoulManager(metaclass=ResourceStateHandler):
     def spend_soul_slow(self):
         ...
 
-    def try_spend_soul(self, state_blob: rs, item_state: cs, amount: int) -> bool:
+    def try_spend_soul(self, state_blob: rs, item_state: cs, amount: int) -> tuple[bool, rs]:
         soul = self.get_soul_info(state_blob, item_state)
         if soul.soul < amount:
-            return False
-        self.spend_and_rebalance(state_blob, item_state, amount, soul)
-        return True
+            return False, state_blob
+        state_blob = self.spend_and_rebalance(state_blob, item_state, amount, soul)
+        return True, state_blob
 
-    def spend_and_rebalance(self, state_blob: rs, item_state: cs, amount: int, soul: SoulInfo) -> None:
-        self.spend_without_rebalance(state_blob, item_state, amount, soul)
-        self.rebalance_reserve(state_blob, item_state, soul)
+    def spend_and_rebalance(self, state_blob: rs, item_state: cs, amount: int, soul: SoulInfo) -> rs:
+        state_blob = self.spend_without_rebalance(state_blob, item_state, amount, soul)
+        state_blob = self.rebalance_reserve(state_blob, item_state, soul)
+        return state_blob
 
-    def spend_without_rebalance(self, state_blob: rs, item_state: cs, amount: int, soul: SoulInfo) -> None:
-        state_blob["SPENTSOUL"] += amount
-        state_blob["REQUIREDMAXSOUL"] = max(state_blob["REQUIREDMAXSOUL"], state_blob["SPENTSOUL"])
+    def spend_without_rebalance(self, state_blob: rs, item_state: cs, amount: int, soul: SoulInfo) -> rs:
+        state_blob = rs_add_value(state_blob, "SPENTSOUL", amount)
+        state_blob = rs_increase_if_lower(state_blob, "REQUIREDMAXSOUL", rs_get_value(state_blob, "SPENTSOUL"))
         soul.soul -= amount
+        return state_blob
 
-    def rebalance_reserve(self, state_blob: rs, item_state: cs, soul: SoulInfo) -> None:
+    def rebalance_reserve(self, state_blob: rs, item_state: cs, soul: SoulInfo) -> rs:
         transfer = min(soul.max_soul - soul.soul, soul.reserve_soul)
         if transfer > 0:
-            state_blob["SPENTSOUL"] -= transfer
-            state_blob["SPENTRESERVESOUL"] += transfer
+            state_blob = rs_add_value(state_blob, "SPENTSOUL", -transfer)
+            state_blob = rs_add_value(state_blob, "SPENTRESERVESOUL", transfer)
             soul.soul += transfer
             soul.reserve_soul -= transfer
+        return state_blob
 
-    def try_spend_soul_sequence(self, state_blob: rs, item_state: cs, amount: int, casts: list[int]) -> bool:
+    def try_spend_soul_sequence(self, state_blob: rs, item_state: cs, amount: int, casts: list[int]) -> tuple[bool, rs]:
         soul = self.get_soul_info(state_blob, item_state)
         for cast in casts:
             group_total = cast * amount
             if soul.soul < group_total:
-                return False
-            self.spend_and_rebalance(state_blob, item_state, group_total, soul)
-        return True
+                return False, state_blob
+            state_blob = self.spend_and_rebalance(state_blob, item_state, group_total, soul)
+        return True, state_blob
 
     def try_spend_soul_slow(self):
         ...
@@ -82,59 +85,57 @@ class SoulManager(metaclass=ResourceStateHandler):
         ...
 
     def spend_all_soul(self, state_blob: rs, item_state: cs) -> Generator[rs]:
-        ret = state_blob.copy()
-        if self.try_spend_all_soul(ret, item_state):
+        spent, ret = self.try_spend_all_soul(state_blob, item_state)
+        if spent:
             yield ret
 
-    def try_spend_all_soul(self, state_blob: rs, item_state: cs) -> bool:
+    def try_spend_all_soul(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
         info = self.get_soul_info(state_blob, item_state)
-        state_blob["SPENTSOUL"] = info.max_soul
-        state_blob["REQUIREDMAXSOUL"] = info.max_soul
-        state_blob["SPENTRESERVESOUL"] = info.max_reserve_soul
-        return True
+        state_blob = rs_set_value(state_blob, "SPENTSOUL", info.max_soul)
+        state_blob = rs_set_value(state_blob, "REQUIREDMAXSOUL", info.max_soul)
+        state_blob = rs_set_value(state_blob, "SPENTRESERVESOUL", info.max_reserve_soul)
+        return True, state_blob
 
     def restore_soul(self):
         ...
 
     def restore_all_soul(self, state_blob: rs, item_state: cs, restore_reserves: bool) -> Generator[rs]:
-        ret = state_blob.copy()
-        if self.try_restore_all_soul(ret, item_state, restore_reserves):
+        restored, ret = self.try_restore_all_soul(state_blob, item_state, restore_reserves)
+        if restored:
             yield ret
 
     def try_restore_soul(self):
         ...
 
-    def try_restore_all_soul(self, state_blob: rs, item_state: cs, restore_reserves: bool) -> bool:
-        if state_blob["CANNOTREGAINSOUL"]:
-            return False
-        state_blob["SPENTSOUL"] = 0
+    def try_restore_all_soul(self, state_blob: rs, item_state: cs, restore_reserves: bool) -> tuple[bool, rs]:
+        if rs_get_value(state_blob, "CANNOTREGAINSOUL"):
+            return False, state_blob
+        state_blob = rs_set_value(state_blob, "SPENTSOUL", 0)
         if restore_reserves:
-            state_blob["SPENTRESERVESOUL"] = 0
-        return True
+            state_blob = rs_set_value(state_blob, "SPENTRESERVESOUL", 0)
+        return True, state_blob
 
     def get_soul_info(self, state_blob: rs, item_state: cs) -> SoulInfo:
-        max_soul = 99 - state_blob["SOULLIMITER"]
-        soul = max_soul - state_blob["SPENTSOUL"]
-        vessels = item_state.count("VESSELFRAGMENTS", self.player) // 3
+        max_soul = 99 - rs_get_value(state_blob, "SOULLIMITER")
+        soul = max_soul - rs_get_value(state_blob, "SPENTSOUL")
+        vessels = min(6, item_state.count("VESSELFRAGMENTS", self.player) // 3) # max 6 so that state doesn't overflow
         max_reserve_soul = vessels * 33
-        reserve_soul = max_reserve_soul - state_blob["SPENTRESERVESOUL"]
+        reserve_soul = max_reserve_soul - rs_get_value(state_blob, "SPENTRESERVESOUL")
         return SoulInfo(soul, max_soul, reserve_soul, max_reserve_soul)
 
-    def try_set_soul_limit(self, state_blob: rs, item_state: cs, limiter: int, applies_to_prior_path: bool) -> bool:
-        if applies_to_prior_path and state_blob["REQUIREDMAXSOUL"] > limiter:
-            return False
-        current = state_blob["SOULLIMITER"]
-        if limiter > current:
-            state_blob["SOULLIMITER"] = limiter
-        elif limiter < current:
-            state_blob["SOULLIMITER"] = limiter
-            self.try_spend_soul(state_blob, item_state, current - limiter)
-
-        return True
+    def try_set_soul_limit(self, state_blob: rs, item_state: cs, limiter: int, applies_to_prior_path: bool) -> tuple[bool, rs]:
+        if applies_to_prior_path and rs_get_value(state_blob, "REQUIREDMAXSOUL") > 99 - limiter:
+            return False, state_blob
+        current = rs_get_value(state_blob, "SOULLIMITER")
+        if limiter != current:
+            state_blob = rs_add_value(state_blob, "SOULLIMITER", limiter - current)
+        if limiter < current:
+            _, state_blob = self.try_spend_soul(state_blob, item_state, current - limiter)
+        return True, state_blob
 
     def limit_soul(self, state_blob: rs, item_state: cs, limiter: int, applies_to_prior_path: bool) -> Generator[rs]:
-        ret = state_blob.copy()
-        if self.try_set_soul_limit(ret, item_state, limiter, applies_to_prior_path):
+        limited, ret = self.try_set_soul_limit(state_blob, item_state, limiter, applies_to_prior_path)
+        if limited:
             yield ret
 
     def soul_info(self):

--- a/worlds/hk/resource_state_vars/spend_soul.py
+++ b/worlds/hk/resource_state_vars/spend_soul.py
@@ -1,4 +1,4 @@
-from . import RCStateVariable, cs, rs
+from . import RCStateVariable, cs, rs, rs_get_value, rs_add_value, rs_set_value
 
 
 class SpendSoulVariable(RCStateVariable):
@@ -20,7 +20,7 @@ class SpendSoulVariable(RCStateVariable):
     #     return (term for term in ("VessleFragments",))
 
     def _modify_state(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
-        if state_blob["SPENTALLSOUL"]:
+        if rs_get_value(state_blob, "SPENTALLSOUL"):
             return False, state_blob
 
         soul = self.get_soul(state_blob)
@@ -29,23 +29,24 @@ class SpendSoulVariable(RCStateVariable):
 
         reserve_soul = self.get_reserve_soul(state_blob, item_state)
         if reserve_soul >= self.amount:
-            state_blob["SPENTRESERVESOUL"] += self.amount
+            state_blob = rs_add_value(state_blob, "SPENTRESERVESOUL", self.amount)
         else:
-            state_blob["SPENTRESERVESOUL"] += reserve_soul
-            state_blob["SPENTSOUL"] += self.amount - reserve_soul
+            state_blob = rs_add_value(state_blob, "SPENTRESERVESOUL", reserve_soul)
+            state_blob = rs_add_value(state_blob, "SPENTSOUL", self.amount - reserve_soul)
 
-        required_max_soul = state_blob["REQUIREDMAXSOUL"]
-        alt_req = max(self.amount, state_blob["SPENTSOUL"])
+        required_max_soul = rs_get_value(state_blob, "REQUIREDMAXSOUL")
+        alt_req = max(self.amount, rs_get_value(state_blob, "SPENTSOUL"))
         if alt_req > required_max_soul:
-            state_blob["REQUIREDMAXSOUL"] = alt_req
+            state_blob = rs_set_value(state_blob, "REQUIREDMAXSOUL", alt_req)
 
         return True, state_blob
 
     def get_soul(self, state_blob: rs) -> int:
-        return 99 - state_blob["SOULLIMITER"] - state_blob["SPENTSOUL"]
+        return 99 - rs_get_value(state_blob, "SOULLIMITER") - rs_get_value(state_blob, "SPENTSOUL")
 
     def get_reserve_soul(self, state_blob: rs, item_state: cs) -> int:
-        return ((item_state.count("VESSELFRAGMENTS", self.player) // 3) * 33) - state_blob["SPENTRESERVESOUL"]
+        return (((item_state.count("VESSELFRAGMENTS", self.player) // 3) * 33)
+                - rs_get_value(state_blob, "SPENTRESERVESOUL"))
 
     def can_exclude(self, options) -> bool:
         return False

--- a/worlds/hk/resource_state_vars/stag_state.py
+++ b/worlds/hk/resource_state_vars/stag_state.py
@@ -1,4 +1,4 @@
-from . import RCStateVariable, cs, rs
+from . import RCStateVariable, cs, rs, rs_set_value
 
 
 class StagStateVariable(RCStateVariable):
@@ -16,8 +16,7 @@ class StagStateVariable(RCStateVariable):
         return []
 
     def _modify_state(self, state_blob: rs, item_state: cs) -> tuple[bool, rs]:
-        state_blob["NOFLOWER"] = 1
-        return True, state_blob
+        return True, rs_set_value(state_blob, "NOFLOWER", 1)
 
     def can_exclude(self, options) -> bool:
         return False

--- a/worlds/hk/state_mixin.py
+++ b/worlds/hk/state_mixin.py
@@ -6,7 +6,7 @@ from Utils import KeyedDefaultDict
 from worlds.AutoWorld import LogicMixin
 
 from .constants import BASE_HEALTH, BASE_NOTCHES, BASE_SOUL  # noqa: F401
-from .resource_state_vars import rs, rs_set_value, rs_leq, rs_to_dict
+from .resource_state_vars import rs, rs_set_value, rs_leq
 
 if TYPE_CHECKING:
     from . import HKClause

--- a/worlds/hk/state_mixin.py
+++ b/worlds/hk/state_mixin.py
@@ -6,7 +6,7 @@ from Utils import KeyedDefaultDict
 from worlds.AutoWorld import LogicMixin
 
 from .constants import BASE_HEALTH, BASE_NOTCHES, BASE_SOUL  # noqa: F401
-from .resource_state_vars import rs, rs_set_value, rs_leq
+from .resource_state_vars import rs, rs_set_value, rs_leq, rs_to_dict
 
 if TYPE_CHECKING:
     from . import HKClause
@@ -47,6 +47,9 @@ class HKLogicMixin(LogicMixin):
     _hk_entrance_clause_cache: dict[int, dict[str, dict[int, bool]]]
     """mapping for clauses per entrance per player to short circuit non-resource state calculations"""
 
+    _hk_checked_state_modifiers: dict[int, dict[str, set[str]]]
+    """mapping for state modifiers per entrance per player to not try state modifiers which have already been tried"""
+
     _hk_processed_item_cache: dict[int, Counter]
 
     _hk_charm_costs: dict[int, dict[str, int]]
@@ -67,6 +70,7 @@ class HKLogicMixin(LogicMixin):
         self._hk_per_player_sweepable_entrances = {player: set() for player in players}
         self._hk_free_entrances = {player: {"Menu"} for player in players}
         self._hk_entrance_clause_cache = {player: {} for player in players}
+        self._hk_checked_state_modifiers = {player: {} for player in players}
         self._hk_stale = dict.fromkeys(players, True)
         self._hk_sweeping = dict.fromkeys(players, False)
         self._hk_processed_item_cache = {player: Counter() for player in players}
@@ -87,13 +91,34 @@ class HKLogicMixin(LogicMixin):
         if not players:
             return other
         other._hk_per_player_resource_states = {
-            player: self._hk_per_player_resource_states[player].copy()
+            player: KeyedDefaultDict(lambda region: [default_state()] if region == "Menu" else [])
+            for player in players
+        }
+        for player in players:
+            for entrance in self._hk_per_player_resource_states[player]:
+                other._hk_per_player_resource_states[player][entrance] = self._hk_per_player_resource_states[player][entrance].copy()
+        other._hk_entrance_clause_cache = {
+            player: {
+                entrance: self._hk_entrance_clause_cache[player][entrance].copy()
+                for entrance in self._hk_entrance_clause_cache[player]
+            }
+            for player in players
+        }
+        other._hk_checked_state_modifiers = {
+            player: {
+                entrance: self._hk_checked_state_modifiers[player][entrance].copy()
+                for entrance in self._hk_checked_state_modifiers[player]
+            }
             for player in players
         }
         other._hk_free_entrances = {player: self._hk_free_entrances[player].copy() for player in players}
         other._hk_processed_item_cache = {player: self._hk_processed_item_cache[player].copy() for player in players}
+        other._hk_per_player_sweepable_entrances = {
+            player: entrances.copy() for player, entrances in self._hk_per_player_sweepable_entrances.items()
+        }
         return other
         # TODO do we need to copy sweepables? should be empty any time we're mucking with resource state
+        # yes we do, there's nothing stopping a state from being copied while stale
 
     def _hk_apply_and_validate_state(self, clause: "HKClause", region: Region, target_region=None) -> bool:
         player = region.player
@@ -136,38 +161,7 @@ class HKLogicMixin(LogicMixin):
                         break
                 else:
                     ind += 1
-        # for index, s in reversed(list(enumerate(available_states))):
-        #     for previous in target_states:
-        #         if rs_leq(previous, s):
-        #             # if the state we're adding already exists
-        #             # or a better state already exists, we didn't improve
-        #             available_states.pop(index)
-        #             break
         if available_states:
-            # for exit in target_region.exits:
-            #     if exit.hk_rule is None:
-            #         self._hk_per_player_sweepable_entrances[player].add(exit.name)
-            #         continue
-            #     relevant_terms = sorted({
-            #         term
-            #         for clause in exit.hk_rule
-            #         for handler in clause.hk_state_requirements
-            #         for term in handler.terms
-            #     })
-            #     for term in relevant_terms:
-            #         prev = max(0, 0, *[s[term] for s in target_states])
-            #         new = max(0, 0, *[s[term] for s in available_states])
-            #         if prev > new:
-            #             self._hk_per_player_sweepable_entrances[player].add(exit.name)
-            #             break
-
-            # target_states += available_states
-            # for index, s in reversed(list(enumerate(target_states))):
-            #     for other in [t_s for t_s in target_states if t_s is not s]:
-            #         # TODO make sure this doesn't ever break
-            #         if rs_leq(other, s):
-            #             target_states.pop(index)
-            #             break
             if available_states == target_states:
                 return True
             # mergesort-like merging
@@ -175,7 +169,6 @@ class HKLogicMixin(LogicMixin):
             available_index = 0
             new_useful_state = False
             while available_index < len(available_states) or target_index < len(target_states):
-                side_to_check = -1
                 if available_index == len(available_states):
                     side_to_check = 0
                 elif target_index == len(target_states):
@@ -208,7 +201,13 @@ class HKLogicMixin(LogicMixin):
                         target_index += 1
                     available_index += 1
             if new_useful_state:
-                self._hk_per_player_sweepable_entrances[player].update({exit.name for exit in target_region.exits})
+                self.reachable_regions[player].add(target_region)
+                for exit in target_region.exits:
+                    self._hk_per_player_sweepable_entrances[player].add(exit.name)
+                    self._hk_checked_state_modifiers[player][exit.name] = set()
+                for exit in self.multiworld.indirect_connections.get(target_region, set()):
+                    self._hk_per_player_sweepable_entrances[player].add(exit.name)
+                    self._hk_checked_state_modifiers[player][exit.name] = set()
             # self._hk_stale[player] = True
         assert target_states
         return True
@@ -217,8 +216,13 @@ class HKLogicMixin(LogicMixin):
         if self._hk_sweeping[player]:
             return
         self._hk_sweeping[player] = True
+        world = self.multiworld.worlds[player]
+        start = world.get_region(world.origin_region_name)
+        if start not in self.reachable_regions[player]:
+            self.reachable_regions[player].add(start)
+            for start_exit in start.exits:
+                self._hk_per_player_sweepable_entrances[player].add(start_exit.name)
         # assume not stale and only evaluate true clauses
-        # (region can_reach dependencies will be covered by indirect connections)
         while self._hk_per_player_sweepable_entrances[player]:
             # print(self._hk_per_player_sweepable_entrances[player])
             # random pop but i don't really care

--- a/worlds/hk/state_mixin.py
+++ b/worlds/hk/state_mixin.py
@@ -6,6 +6,8 @@ from Utils import KeyedDefaultDict
 from worlds.AutoWorld import LogicMixin
 
 from .constants import BASE_HEALTH, BASE_NOTCHES, BASE_SOUL  # noqa: F401
+from .resource_state_vars import rs, rs_set_value, rs_leq, rs_to_dict
+from ..cvcotm.data.lname import arena_victory
 
 if TYPE_CHECKING:
     from . import HKClause
@@ -14,12 +16,14 @@ if TYPE_CHECKING:
 
 # default_state = KeyedDefaultDict(lambda key: True if key == "NOFLOWER" else False)
 class DefaultStateFactory:
-    def __call__(self, defaults=None) -> Counter:
+    def __call__(self, defaults=None) -> rs:
         if defaults is None:
             defaults = {}
-        ret = Counter({"NOFLOWER": 1, "NOPASSEDCHARMEQUIP": 1})
+        ret = 0
+        ret = rs_set_value(ret, "NOFLOWER", 1)
+        ret = rs_set_value(ret, "NOPASSEDCHARMEQUIP", 1)
         for key, value in defaults.items():
-            ret[key] = value
+            ret = rs_set_value(ret, key, value)
         return ret
 
 
@@ -28,8 +32,8 @@ default_state = DefaultStateFactory()
 
 class HKLogicMixin(LogicMixin):
     multiworld: MultiWorld
-    _hk_per_player_resource_states: dict[int, dict[str, list[Counter]]]
-    """resource state blob to map regions and their avalible resource states"""
+    _hk_per_player_resource_states: dict[int, dict[str, list[int]]]
+    """resource state blob to map regions and their available resource states"""
     # state blob is [Counter({"DAMAGE": 0, "SPENTSOUL": 0, "NOFLOWER": 0, "CHARMNOTCHESSPENT": 0})]
 
     _hk_per_player_sweepable_entrances: dict[int, set[str]]
@@ -94,41 +98,53 @@ class HKLogicMixin(LogicMixin):
 
     def _hk_apply_and_validate_state(self, clause: "HKClause", region: Region, target_region=None) -> bool:
         player = region.player
-        # avaliable_states = self._hk_per_player_resource_states[player].get(region.name, None)
+        # available_states = self._hk_per_player_resource_states[player].get(region.name, None)
 
-        # if avaliable_states is None:
+        # if available_states is None:
         #     region.can_reach(self)
-        #     avaliable_states = self._hk_per_player_resource_states[player].get(region.name, [])
+        #     available_states = self._hk_per_player_resource_states[player].get(region.name, [])
 
         # unneeded?
-        avaliable_states = [s.copy() for s in self._hk_per_player_resource_states[player][region.name]]
+        available_states = [s for s in self._hk_per_player_resource_states[player][region.name]]
         # loses the can_reach parent call, potentially re-add it?
 
-        if not avaliable_states:
+        if not available_states:
             # no valid parent states
             return False
 
         for handler in clause.hk_state_requirements:
-            avaliable_states = [
+            available_states = [
                 s
-                for input_state in avaliable_states
+                for input_state in available_states
                 for s in handler.modify_state(input_state, self)
             ]
 
-        if not avaliable_states:
+        if not available_states:
             return False
         if not target_region:
             # don't persist
             return True
         target_states = self._hk_per_player_resource_states[player][target_region.name]
-        for index, s in reversed(list(enumerate(avaliable_states))):
-            for previous in target_states:
-                if eq(s, previous) or lt(previous, s):
-                    # if the state we're adding already exists
-                    # or a better state already exists, we didn't improve
-                    avaliable_states.pop(index)
-                    break
-        if avaliable_states:
+        if target_states == [0]:
+            return True
+        if len(available_states) > 1:
+            available_states.sort()
+            ind = 1
+            while ind < len(available_states):
+                for prev in range(ind):
+                    if rs_leq(available_states[prev],available_states[ind]):
+                        available_states.pop(ind)
+                        break
+                else:
+                    ind += 1
+        # for index, s in reversed(list(enumerate(available_states))):
+        #     for previous in target_states:
+        #         if rs_leq(previous, s):
+        #             # if the state we're adding already exists
+        #             # or a better state already exists, we didn't improve
+        #             available_states.pop(index)
+        #             break
+        if available_states:
             # for exit in target_region.exits:
             #     if exit.hk_rule is None:
             #         self._hk_per_player_sweepable_entrances[player].add(exit.name)
@@ -141,21 +157,59 @@ class HKLogicMixin(LogicMixin):
             #     })
             #     for term in relevant_terms:
             #         prev = max(0, 0, *[s[term] for s in target_states])
-            #         new = max(0, 0, *[s[term] for s in avaliable_states])
+            #         new = max(0, 0, *[s[term] for s in available_states])
             #         if prev > new:
             #             self._hk_per_player_sweepable_entrances[player].add(exit.name)
             #             break
 
-            target_states += avaliable_states
-
-            for index, s in reversed(list(enumerate(target_states))):
-                for other in [t_s for t_s in target_states if t_s is not s]:
-                    # TODO make sure this doesn't ever break
-                    if lt(other, s):
-                        target_states.pop(index)
-                        break
-
-            self._hk_per_player_sweepable_entrances[player].update({exit.name for exit in target_region.exits})
+            # target_states += available_states
+            # for index, s in reversed(list(enumerate(target_states))):
+            #     for other in [t_s for t_s in target_states if t_s is not s]:
+            #         # TODO make sure this doesn't ever break
+            #         if rs_leq(other, s):
+            #             target_states.pop(index)
+            #             break
+            if available_states == target_states:
+                return True
+            # mergesort-like merging
+            target_index = 0
+            available_index = 0
+            new_useful_state = False
+            while available_index < len(available_states) or target_index < len(target_states):
+                side_to_check = -1
+                if available_index == len(available_states):
+                    side_to_check = 0
+                elif target_index == len(target_states):
+                    side_to_check = 1
+                elif target_states[target_index] == available_states[available_index]:
+                    # since it's in target_states it's not always worse than any state there
+                    # and since it's in available_states it's not always worse than any state there
+                    # so we're always free to let it stay
+                    available_index += 1
+                    target_index += 1
+                    continue
+                elif target_states[target_index] < available_states[available_index]:
+                    side_to_check = 0
+                else:
+                    side_to_check = 1
+                if side_to_check == 0:
+                    for prev in range(target_index):
+                        if rs_leq(target_states[prev], target_states[target_index]):
+                            target_states.pop(target_index)
+                            break
+                    else:
+                        target_index += 1
+                elif side_to_check == 1:
+                    for prev in range(target_index):
+                        if rs_leq(target_states[prev], available_states[available_index]):
+                            break
+                    else:
+                        new_useful_state = True
+                        target_states.insert(target_index, available_states[available_index])
+                        target_index += 1
+                    available_index += 1
+            if new_useful_state:
+                self._hk_per_player_sweepable_entrances[player].update({exit.name for exit in target_region.exits})
             # self._hk_stale[player] = True
         assert target_states
         return True

--- a/worlds/hk/state_mixin.py
+++ b/worlds/hk/state_mixin.py
@@ -6,8 +6,7 @@ from Utils import KeyedDefaultDict
 from worlds.AutoWorld import LogicMixin
 
 from .constants import BASE_HEALTH, BASE_NOTCHES, BASE_SOUL  # noqa: F401
-from .resource_state_vars import rs, rs_set_value, rs_leq, rs_to_dict
-from ..cvcotm.data.lname import arena_victory
+from .resource_state_vars import rs, rs_set_value, rs_leq
 
 if TYPE_CHECKING:
     from . import HKClause

--- a/worlds/hk/test/test_resource_equip.py
+++ b/worlds/hk/test/test_resource_equip.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from test.param import classvar_matrix
 
 from ..charms import charm_name_to_id, charm_names
+from ..resource_state_vars import rs, rs_get_value, rs_set_value, dict_to_rs
 from ..resource_state_vars.equip_charm import EquipCharmVariable
 from .bases import NoStepHK, StateVarSetup
 
@@ -31,40 +32,41 @@ class TestBasicEquips(StateVarSetup, NoStepHK):
         rs, cs = self.get_initialized_args()
         handler = self.get_handler()
 
-        self.assertFalse(handler.try_equip(rs, cs))
+        equipped, rs = handler.try_equip(rs, cs)
+        self.assertFalse(equipped)
         self.assertFalse(handler.is_equipped(rs))
-        self.assertEqual(rs["USEDNOTCHES"], 0)
-        self.assertEqual(rs["MAXNOTCHCOST"], 0)
+        self.assertEqual(rs_get_value(rs, "USEDNOTCHES"), 0)
+        self.assertEqual(rs_get_value(rs, "MAXNOTCHCOST"), 0)
 
-        rs["NOPASSEDCHARMEQUIP"] = 0
+        rs = rs_set_value(rs, "NOPASSEDCHARMEQUIP", 0)
         res_bool, res_state = handler._try_equip(rs, cs)
         self.assertTrue(res_bool)
         # test original state
         self.assertFalse(handler.is_equipped(rs))
-        self.assertEqual(rs["USEDNOTCHES"], 0)
-        self.assertEqual(rs["MAXNOTCHCOST"], 0)
+        self.assertEqual(rs_get_value(rs, "USEDNOTCHES"), 0)
+        self.assertEqual(rs_get_value(rs, "MAXNOTCHCOST"), 0)
         # test output state
         self.assertTrue(handler.is_equipped(res_state))
-        self.assertEqual(res_state["USEDNOTCHES"], 1)
-        self.assertEqual(res_state["MAXNOTCHCOST"], 1)
+        self.assertEqual(rs_get_value(res_state, "USEDNOTCHES"), 1)
+        self.assertEqual(rs_get_value(res_state, "MAXNOTCHCOST"), 1)
 
-        other = rs.copy()  # for later
+        other = rs  # for later
 
-        handler.set_unequippable(rs)
-        res_bool = handler.try_equip(rs, cs)
+        rs = handler.set_unequippable(rs)
+        res_bool, rs = handler.try_equip(rs, cs)
         self.assertFalse(res_bool)
-        self.assertEqual(rs["USEDNOTCHES"], 0)
-        self.assertEqual(rs["MAXNOTCHCOST"], 0)
+        self.assertEqual(rs_get_value(rs, "USEDNOTCHES"), 0)
+        self.assertEqual(rs_get_value(rs, "MAXNOTCHCOST"), 0)
 
-        other_bool = handler.try_equip(other, cs)
+        other_bool, other = handler.try_equip(other, cs)
         self.assertTrue(other_bool)
-        self.assertEqual(other["USEDNOTCHES"], 1)
-        self.assertEqual(other["MAXNOTCHCOST"], 1)
+        self.assertEqual(rs_get_value(other, "USEDNOTCHES"), 1)
+        self.assertEqual(rs_get_value(other, "MAXNOTCHCOST"), 1)
 
-        other_bool = handler.try_equip(other, cs)
+        other_bool, other = handler.try_equip(other, cs)
         self.assertTrue(other_bool)
-        self.assertEqual(other["USEDNOTCHES"], 1)
-        self.assertEqual(other["MAXNOTCHCOST"], 1)
+        self.assertEqual(rs_get_value(other, "USEDNOTCHES"), 1)
+        self.assertEqual(rs_get_value(other, "MAXNOTCHCOST"), 1)
 
 
 equip_notch_matrix = [
@@ -113,10 +115,10 @@ class TestEquipNotch(StateVarSetup, NoStepHK):
         handlers = [self.get_handler(f"$EQUIPPEDCHARM[{key}]") for key in charm_item_names[:self.charm_count]]
 
         for i in range(self.charm_count):
-            result = handlers[i].try_equip(rs, cs)
+            result, rs = handlers[i].try_equip(rs, cs)
             assert result == self.equip_results[i]
 
-        assert rs["OVERCHARMED"] == self.ended_overcharmed
+        assert rs_get_value(rs, "OVERCHARMED") == self.ended_overcharmed
 
 
 class TestGenerateCharmCombos(StateVarSetup, NoStepHK):
@@ -125,10 +127,10 @@ class TestGenerateCharmCombos(StateVarSetup, NoStepHK):
 
     charm_count: int = 2
     notch_costs: Iterable[int] = (3, 6)
-    expecteds: ClassVar[dict[str, int]] = [
-        {"NOPASSEDCHARMEQUIP": 0, "noCHARM1": 1, "noCHARM2": 1},
-        {"NOPASSEDCHARMEQUIP": 0, "CHARM1": 1, "noCHARM2": 1, "USEDNOTCHES": 3, "MAXNOTCHCOST": 3},
-        {"NOPASSEDCHARMEQUIP": 0, "noCHARM1": 1, "CHARM2": 1, "OVERCHARMED": 1,  "USEDNOTCHES": 6, "MAXNOTCHCOST": 6},
+    expecteds: ClassVar[list[rs]] = [
+        dict_to_rs({"NOPASSEDCHARMEQUIP": 0, "noCHARM1": 1, "noCHARM2": 1}),
+        dict_to_rs({"NOPASSEDCHARMEQUIP": 0, "CHARM1": 1, "noCHARM2": 1, "USEDNOTCHES": 3, "MAXNOTCHCOST": 3}),
+        dict_to_rs({"NOPASSEDCHARMEQUIP": 0, "noCHARM1": 1, "CHARM2": 1, "OVERCHARMED": 1,  "USEDNOTCHES": 6, "MAXNOTCHCOST": 6}),
     ]
     notch_override = 3
 
@@ -145,7 +147,7 @@ class TestGenerateCharmCombos(StateVarSetup, NoStepHK):
 
     def test_combos(self):
         rs, cs = self.get_initialized_args()
-        del rs["NOFLOWER"]  # TODO: get rid of this exception probably
+        rs = rs_set_value(rs, "NOFLOWER", 0)  # TODO: get rid of this exception probably
         handlers = [self.get_handler(f"$EQUIPPEDCHARM[{key}]") for key in charm_item_names[:self.charm_count]]
 
         output_states = EquipCharmVariable.generate_charm_combinations(rs, cs, handlers)

--- a/worlds/hk/test/test_resource_hp.py
+++ b/worlds/hk/test/test_resource_hp.py
@@ -1,6 +1,7 @@
 from typing import ClassVar
 
 from ..resource_state_vars.health_manager import HealthManager
+from ..resource_state_vars import rs_get_value, rs_set_value
 from .bases import NoStepHK, StateVarSetup
 
 
@@ -11,7 +12,7 @@ class TestHPManager(StateVarSetup, NoStepHK):
     prep_vars = ()
 
     def assert_spent_health(self, rs, lazy: int, white: int, blue: int):
-        healths = rs["LAZYSPENTHP"], rs["SPENTHP"], rs["SPENTBLUEHP"]
+        healths = rs_get_value(rs, "LAZYSPENTHP"), rs_get_value(rs, "SPENTHP"), rs_get_value(rs, "SPENTBLUEHP")
         self.assertEqual(healths, (lazy, white, blue), (
             f"Expected LAZYSPENTHP={'max' if lazy == HealthManager.max_damage else lazy}, "
             f"SPENTHP={white}, SPENTBLUEHP={blue}, but were {healths} instead."
@@ -25,15 +26,15 @@ class TestHPManager(StateVarSetup, NoStepHK):
         self.assertEqual(len(states), 2)
         for s in states:
             self.assertTrue(manager.is_hp_determined(s))
-        oc = next(s for s in states if s["OVERCHARMED"])
-        noc = next(s for s in states if s["CANNOTOVERCHARM"])
-        self.assertFalse(oc["CANNOTOVERCHARM"])
-        self.assertFalse(noc["OVERCHARMED"])
+        oc = next(s for s in states if rs_get_value(s, "OVERCHARMED"))
+        noc = next(s for s in states if rs_get_value(s, "CANNOTOVERCHARM"))
+        self.assertFalse(rs_get_value(oc, "CANNOTOVERCHARM"))
+        self.assertFalse(rs_get_value(noc, "OVERCHARMED"))
 
         oc_damage = self.get_one_state(manager.take_damage, oc, cs, 1)
-        self.assertEqual(oc_damage["SPENTHP"], 2)
+        self.assertEqual(rs_get_value(oc_damage, "SPENTHP"), 2)
         noc_damage = self.get_one_state(manager.take_damage, noc, cs, 1)
-        self.assertEqual(noc_damage["SPENTHP"], 1)
+        self.assertEqual(rs_get_value(noc_damage, "SPENTHP"), 1)
 
     def test_lazy_to_strict(self):
         rs, cs = self.get_initialized_args()
@@ -62,9 +63,9 @@ class TestJoniHP(StateVarSetup, NoStepHK):
         rs, cs = self.get_initialized_args()
         manager = self.get_handler()
         joni_handler = self.get_handler("$EQUIPPEDCHARM[Joni's_Blessing]")
-
-        self.assertTrue(joni_handler.try_equip(rs, cs))
-        rs["CANNOTOVERCHARM"] = 1
+        joni_equipped, rs = joni_handler.try_equip(rs, cs)
+        self.assertTrue(joni_equipped)
+        rs = rs_set_value(rs, "CANNOTOVERCHARM", 1)
 
         rs = next(manager.determine_hp(rs, cs))
         hp = manager.get_hp_info(rs, cs)

--- a/worlds/hk/test/test_resource_soul.py
+++ b/worlds/hk/test/test_resource_soul.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from test.param import classvar_matrix
 
 from .bases import NoStepHK, StateVarSetup
+from ..resource_state_vars import rs_get_value
 
 
 @dataclass
@@ -56,10 +57,10 @@ class TestSoulSpend(StateVarSetup, NoStepHK):
         for i, expected in enumerate(self.expecteds):
             states = [s for rs in states for s in manager.spend_soul(rs, cs, 33)]
             self.assertEqual([(
-                    s["SPENTSOUL"],
-                    s["SPENTRESERVESOUL"],
-                    s["REQUIREDMAXSOUL"],
-                    s["SOULLIMITER"],
+                    rs_get_value(s, "SPENTSOUL"),
+                    rs_get_value(s, "SPENTRESERVESOUL"),
+                    rs_get_value(s, "REQUIREDMAXSOUL"),
+                    rs_get_value(s, "SOULLIMITER"),
                 ) for s in states], expected, f"Failed on expected index {i}")
 
 
@@ -93,24 +94,24 @@ class TestRestoreSpend(StateVarSetup, NoStepHK):
 
         if self.limit:
             rs = self.get_one_state(manager.limit_soul, rs, cs, self.limit, True)
-        rs2 = rs.copy()
+        rs2 = rs
 
         rs = self.get_one_state(manager.spend_soul, rs, cs, 66)
         rs = self.get_one_state(manager.restore_all_soul, rs, cs, True)
         self.assertEqual((
-                    rs["SPENTSOUL"],
-                    rs["SPENTRESERVESOUL"],
-                    rs["REQUIREDMAXSOUL"],
-                    rs["SOULLIMITER"],
+                    rs_get_value(rs, "SPENTSOUL"),
+                    rs_get_value(rs, "SPENTRESERVESOUL"),
+                    rs_get_value(rs, "REQUIREDMAXSOUL"),
+                    rs_get_value(rs, "SOULLIMITER"),
                 ), self.expected, "test one")
 
         rs2 = self.get_one_state(manager.spend_all_soul, rs2, cs)
         rs2 = self.get_one_state(manager.restore_all_soul, rs2, cs, True)
         self.assertEqual((
-                    rs2["SPENTSOUL"],
-                    rs2["SPENTRESERVESOUL"],
-                    rs2["REQUIREDMAXSOUL"],
-                    rs2["SOULLIMITER"],
+                    rs_get_value(rs2, "SPENTSOUL"),
+                    rs_get_value(rs2, "SPENTRESERVESOUL"),
+                    rs_get_value(rs2, "REQUIREDMAXSOUL"),
+                    rs_get_value(rs2, "SOULLIMITER"),
                 ), (
                 self.expected[0],
                 self.expected[1],
@@ -157,8 +158,8 @@ class TestRoundSpend(StateVarSetup, NoStepHK):
         else:
             self.assertEqual(len(outputs), 1)
             self.assertEqual((
-                        outputs[0]["SPENTSOUL"],
-                        outputs[0]["SPENTRESERVESOUL"],
-                        outputs[0]["REQUIREDMAXSOUL"],
-                        outputs[0]["SOULLIMITER"],
+                        rs_get_value(outputs[0], "SPENTSOUL"),
+                        rs_get_value(outputs[0], "SPENTRESERVESOUL"),
+                        rs_get_value(outputs[0], "REQUIREDMAXSOUL"),
+                        rs_get_value(outputs[0], "SOULLIMITER"),
                     ), self.expected)

--- a/worlds/hk/test/test_resource_state_vars.py
+++ b/worlds/hk/test/test_resource_state_vars.py
@@ -96,6 +96,7 @@ input_matrix = [
     Inputs("$SHADESKIP", resource={"USEDSHADE": 1}, assert_empty=True),
     Inputs("$SHADESKIP", resource={"CHARM36": 3}, assert_empty=True),
     Inputs("$SHADESKIP", resource={"REQUIREDMAXSOUL": 67}, assert_empty=True),
+    Inputs("$SHADESKIP", prep_vars=("$CASTSPELL[2]",)),
     Inputs("$SHADESKIP"),
     Inputs("$SHADESKIP[2HITS]", masks=4, assert_empty=True),
     Inputs("$SHADESKIP[2HITS]", masks=16),


### PR DESCRIPTION
This PR changes the resource state from a Counter to an Int, ignores Core's sweep and makes the same entrance with the same possible resource states not try to use the same state modifier multiple times, along with a few minor bugfixes(most notably, I'm pretty sure creating playthrough shouldn't fail anymore). From my testing these changes seem to speed up generation by a factor of about 2x.