### PR TITLE
Second pass at versioning api and docs

### DIFF
--- a/WebHostLib/api/__init__.py
+++ b/WebHostLib/api/__init__.py
@@ -4,10 +4,12 @@ from typing import List, Tuple
 from flask import Blueprint
 from flask_cors import CORS
 
+from Utils import __version__
 from ..models import Seed, Slot
 
 api_endpoints = Blueprint('api', __name__, url_prefix="/api")
 cors = CORS(api_endpoints, resources={
+                r"/api/version": {"origins": "*"},
                 r"/api/datapackage/*": {"origins": "*"},
                 r"/api/datapackage": {"origins": "*"},
                 r"/api/datapackage_checksum/*": {"origins": "*"},
@@ -23,3 +25,12 @@ def get_players(seed: Seed) -> List[Tuple[str, str]]:
 
 # trigger endpoint registration
 from . import datapackage, generate, room, tracker, user
+
+API_VERSION = {
+    "ap_core_version": __version__,
+    "tracker_api_version": str(tracker.TRACKER_VERSION)
+}
+
+@api_endpoints.route("/version")
+def version() -> dict[str, str]:
+    return API_VERSION

--- a/WebHostLib/api/tracker.py
+++ b/WebHostLib/api/tracker.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, TypedDict
 from uuid import UUID
@@ -5,10 +6,21 @@ from uuid import UUID
 from flask import abort
 
 from NetUtils import ClientStatus, Hint, NetworkItem, SlotType
+from Utils import __version__
 from WebHostLib import cache
 from WebHostLib.api import api_endpoints
 from WebHostLib.models import Room
 from WebHostLib.tracker import TrackerData
+
+TRACKER_MINOR_VERSION = 2
+
+
+@api_endpoints.route("/tracker/version")
+def version() -> dict[str, str]:
+    return {
+        "major": str(__version__),
+        "minor": str(TRACKER_MINOR_VERSION)
+    }
 
 
 class PlayerAlias(TypedDict):
@@ -52,16 +64,15 @@ class PlayerStatus(TypedDict):
     status: ClientStatus
 
 
-class PlayerLocationsTotal(TypedDict):
+class TrackerPlayerData(TypedDict):
     team: int
     player: int
-    total_locations: int
-
-
-class PlayerGame(TypedDict):
-    team: int
-    player: int
-    game: str
+    alias: str | None
+    items: list[NetworkItem]
+    checked_locations: list[int]
+    hints: list[Hint]
+    time: datetime | None
+    status: ClientStatus
 
 
 @api_endpoints.route("/tracker/<suuid:tracker>")
@@ -82,28 +93,6 @@ def tracker_data(tracker: UUID) -> dict[str, Any]:
 
     all_players: dict[int, list[int]] = tracker_data.get_all_players()
 
-    player_aliases: list[PlayerAlias] = []
-    """Slot aliases of all players."""
-    for team, players in all_players.items():
-        for player in players:
-            player_aliases.append(
-                {"team": team, "player": player, "alias": tracker_data.get_player_alias(team, player)})
-
-    player_items_received: list[PlayerItemsReceived] = []
-    """Items received by each player."""
-    for team, players in all_players.items():
-        for player in players:
-            player_items_received.append(
-                {"team": team, "player": player, "items": tracker_data.get_player_received_items(team, player)})
-
-    player_checks_done: list[PlayerChecksDone] = []
-    """ID of all locations checked by each player."""
-    for team, players in all_players.items():
-        for player in players:
-            player_checks_done.append(
-                {"team": team, "player": player,
-                 "locations": sorted(tracker_data.get_player_checked_locations(team, player))})
-
     total_checks_done: list[TeamTotalChecks] = [
         {"team": team, "checks_done": checks_done}
         for team, checks_done in tracker_data.get_team_locations_checked_count().items()
@@ -111,59 +100,51 @@ def tracker_data(tracker: UUID) -> dict[str, Any]:
     """Total number of locations checked for the entire multiworld per team."""
 
     hints: list[PlayerHints] = []
+    hints: dict[tuple[int, int], list[PlayerHints]] = defaultdict(list)
     """Hints that all players have used or received."""
     for team, players in tracker_data.get_all_slots().items():
         for player in players:
             player_hints = sorted(tracker_data.get_player_hints(team, player))
-            hints.append({"team": team, "player": player, "hints": player_hints})
+            hints[team, player] += player_hints
             slot_info = tracker_data.get_slot_info(player)
             # this assumes groups are always after players
             if slot_info.type != SlotType.group:
                 continue
             for member in slot_info.group_members:
-                hints[member - 1]["hints"] += player_hints
+                hints[team, member] += player_hints
 
-    activity_timers: list[PlayerTimer] = []
-    """Time of last activity per player. Returned as RFC 1123 format and null if no connection has been made."""
-    for team, players in all_players.items():
+    activity_timers = dict(tracker_data._multisave.get("client_activity_timers", []))
+    connection_timers = dict(tracker_data._multisave.get("client_connection_timers", []))
+
+    def get_time(lookup, key) -> datetime | None:
+        ret = lookup.get(key)
+        if ret is not None:
+            return datetime.fromtimestamp(ret, timezone.utc)
+        return ret
+
+    player_data: list[TrackerPlayerData] = []
+    for team, player in all_players.items():
         for player in players:
-            activity_timers.append({"team": team, "player": player, "time": None})
-
-    for (team, player), timestamp in tracker_data._multisave.get("client_activity_timers", []):
-        for entry in activity_timers:
-            if entry["team"] == team and entry["player"] == player:
-                entry["time"] = datetime.fromtimestamp(timestamp, timezone.utc)
-                break
-
-    connection_timers: list[PlayerTimer] = []
-    """Time of last connection per player. Returned as RFC 1123 format and null if no connection has been made."""
-    for team, players in all_players.items():
-        for player in players:
-            connection_timers.append({"team": team, "player": player, "time": None})
-
-    for (team, player), timestamp in tracker_data._multisave.get("client_connection_timers", []):
-        # find the matching entry
-        for entry in connection_timers:
-            if entry["team"] == team and entry["player"] == player:
-                entry["time"] = datetime.fromtimestamp(timestamp, timezone.utc)
-                break
-
-    player_status: list[PlayerStatus] = []
-    """The current client status for each player."""
-    for team, players in all_players.items():
-        for player in players:
-            player_status.append(
-                {"team": team, "player": player, "status": tracker_data.get_player_client_status(team, player)})
+            if tracker_data.get_slot_info(player).type == SlotType.group:
+                continue
+            items = [
+                (item, -2, 0, 0) for item in tracker_data.get_player_starting_inventory(player)
+                ] + tracker_data.get_player_received_items(team, player)
+            player_data.append({
+                "team": team,
+                "player": player,
+                "alias": tracker_data.get_player_alias(team, player),
+                "items": items,
+                "checked_locations": sorted(tracker_data.get_player_checked_locations(team, player)),
+                "hints": hints[team, player],
+                "activity_time": get_time(activity_timers, (team, player)),
+                "connection_time": get_time(connection_timers, (team, player)),
+                "status": tracker_data.get_player_client_status(team, player),
+                })
 
     return {
-        "aliases": player_aliases,
-        "player_items_received": player_items_received,
-        "player_checks_done": player_checks_done,
         "total_checks_done": total_checks_done,
-        "hints": hints,
-        "activity_timers": activity_timers,
-        "connection_timers": connection_timers,
-        "player_status": player_status,
+        "player_data": player_data,
     }
 
 
@@ -173,9 +154,13 @@ class PlayerGroups(TypedDict):
     members: list[int]
 
 
-class PlayerSlotData(TypedDict):
+class StaticPlayerData(TypedDict):
+    team: int
     player: int
-    slot_data: dict[str, Any]
+    name: str
+    location_count: int
+    locations: list[int]
+    game: str
 
 
 @api_endpoints.route("/static_tracker/<suuid:tracker>")
@@ -210,24 +195,31 @@ def static_tracker_data(tracker: UUID) -> dict[str, Any]:
                 })
         break
 
-    player_locations_total: list[PlayerLocationsTotal] = []
-    for team, players in all_players.items():
+    player_data: list[StaticPlayerData] = []
+    for team, players in tracker_data.get_all_slots().items():
         for player in players:
-            player_locations_total.append(
-                {"team": team, "player": player, "total_locations": len(tracker_data.get_player_locations(player))})
-
-    player_game: list[PlayerGame] = []
-    """The played game per player slot."""
-    for team, players in all_players.items():
-        for player in players:
-            player_game.append({"team": team, "player": player, "game": tracker_data.get_player_game(player)})
+            if tracker_data.get_slot_info(player).type == SlotType.group:
+                continue
+            locations = tracker_data.get_player_locations(player).keys()
+            player_data.append({
+                "team": team,
+                "player": player,
+                "name": tracker_data.get_player_name(player),
+                "location_count": len(locations),
+                "locations": sorted(locations),
+                "game": tracker_data.get_player_game(player),
+                })
 
     return {
         "groups": groups,
         "datapackage": tracker_data._multidata["datapackage"],
-        "player_locations_total": player_locations_total,
-        "player_game": player_game,
+        "player_data": player_data,
     }
+
+
+class PlayerSlotData(TypedDict):
+    player: int
+    slot_data: dict[str, Any]
 
 
 # It should be exceedingly rare that slot data is needed, so it's separated out.

--- a/WebHostLib/api/tracker.py
+++ b/WebHostLib/api/tracker.py
@@ -13,14 +13,11 @@ from WebHostLib.models import Room
 from WebHostLib.tracker import TrackerData
 
 TRACKER_MINOR_VERSION = 2
-
+TRACKER_VERSION = {"major": __version__, "minor": str(TRACKER_MINOR_VERSION)}
 
 @api_endpoints.route("/tracker/version")
 def version() -> dict[str, str]:
-    return {
-        "major": str(__version__),
-        "minor": str(TRACKER_MINOR_VERSION)
-    }
+    return TRACKER_VERSION
 
 
 class PlayerAlias(TypedDict):

--- a/WebHostLib/api/tracker.py
+++ b/WebHostLib/api/tracker.py
@@ -6,19 +6,13 @@ from uuid import UUID
 from flask import abort
 
 from NetUtils import ClientStatus, Hint, NetworkItem, SlotType
-from Utils import __version__
 from WebHostLib import cache
 from WebHostLib.api import api_endpoints
 from WebHostLib.models import Room
 from WebHostLib.tracker import TrackerData
 
 
-TRACKER_MINOR_VERSION = 2
-TRACKER_VERSION = {"major": __version__, "minor": str(TRACKER_MINOR_VERSION)}
-
-@api_endpoints.route("/tracker/version")
-def version() -> dict[str, str]:
-    return TRACKER_VERSION
+TRACKER_VERSION = 2
 
 
 class PlayerAlias(TypedDict):

--- a/WebHostLib/api/tracker.py
+++ b/WebHostLib/api/tracker.py
@@ -6,7 +6,6 @@ from uuid import UUID
 from flask import abort
 
 from NetUtils import ClientStatus, Hint, NetworkItem, SlotType
-from Utils import __version__
 from WebHostLib import cache
 from WebHostLib.api import api_endpoints
 from WebHostLib.models import Room

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -17,6 +17,7 @@ Current endpoints:
 - Room API
     - [`/room_status/<suuid:room_id>`](#roomstatus)
 - Tracker API
+    - [`/tracker/version`](#tracker_version)
     - [`/tracker/<suuid:tracker>`](#tracker)
     - [`/static_tracker/<suuid:tracker>`](#statictracker)
     - [`/slot_data_tracker/<suuid:tracker>`](#slotdatatracker)
@@ -28,6 +29,34 @@ Current endpoints:
 To reduce the strain on an Archipelago WebHost, many API endpoints will cache their data and only poll new data in timed intervals. Each endpoint has their own caching time related to the type of data being served. More dynamic data is refreshed more frequently, while static data is cached for longer.  
 Each API endpoint will have their "Cache timer" listed under their definition (if any).
 API calls to these endpoints should not be faster than the listed timer. This will result in wasted processing for your client and (more importantly) the Archipelago WebHost, as the data will not be refreshed by the WebHost until the internal timer has elapsed.
+
+## API Versions
+<a name="apiversion"></a>
+In order to provide the ability for applications to verify they have the correct API specs, each API endpoint is given a `Major` and `Minor` version number via their own `/<endpoint>/version`.  
+Example:
+```json
+{
+    "major": "0.6.7",
+    "minor": "1"
+}
+```
+You'll receive a dict that contains two entries:
+- `Major` will always report the running release of the Archipelago server.
+- `Minor` will report the version of the endpoint that is running.
+
+If your application is programmed for `/tracker/version` `major: 0.6.7` and `minor: 1`, and your application reports something else, you'll know you need to update your application's API spec, and error accordingly.  
+You will also have the ability to support multiple versions of the API spec in this manner. Allowing you to support more than just a single version of Archipelago at a time.
+
+**As changes are made to the API, the minor version may increase independently of the major Archipelago release version.**  
+In most of cases, the minor version will always be `1`. However, you should be prepared to handle other minor versions if changes to the API are deployed out-of-release.
+
+### Historical API Documentation
+Below are the 5 most recent versions of the API spec.
+- [0.6.7](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.7/docs/webhost%20api.md)
+- [0.6.6](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.6/docs/webhost%20api.md) (Note: This was a core security-only release)
+- [0.6.5](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.5/docs/webhost%20api.md)
+- [0.6.4](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.4/docs/webhost%20api.md)
+- [0.6.3](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.3/docs/webhost%20api.md)
 
 
 ## Datapackage Endpoints
@@ -270,140 +299,60 @@ Example:
 Endpoints to fetch information regarding players of an active WebHost room with the supplied tracker_ID. The tracker ID
 can either be viewed while on a room tracker page, or from the [room's endpoint](#room-endpoints).
 
+### `/tracker/version`
+<a name=tracker_version></a>
+[See API Version](#apiversion)
+
 ### `/tracker/<suuid:tracker>`
 <a name=tracker></a>
 **Cache timer: 60 seconds**
 
 Will provide a dict of tracker data with the following keys:
 
-- A list of players current alias data (`aliases`)
-  - Each item containing a dict with, their alias `alias`, their player number `player`, and their team `team`
-  - `alias` will return `null` if there is no alias set
-- A list of items each player has received as a [NetworkItem](network%20protocol.md#networkitem) (`player_items_received`)
-  - Each item containing a dict with, a list of NetworkItems `items`, their player number `player`, their team `team`
-- A list of checks done by each player as a list of the location id's (`player_checks_done`)
-  - Each item containing a dict with, a list of checked location id's `locations`, their player number `player`, and their team `team`
-- A list of the total number of checks done by all players (`total_checks_done`)
-  - Each item will contain a dict with, the total checks done `checks_done`, and the team `team`  
-- A list of [Hints](network%20protocol.md#hint) data that players have used or received (`hints`)
-  - Each item containing a dict containing, a list of hint data `hints`, the player number `player`, and their team `team`
-- A list containing the last activity time for each player, formatted in RFC 1123 format (`activity_timers`)
-  - Each item containing, last activity time `time`, their player number `player`, and their team `team`
-- A list containing the last connection time for each player, formatted in RFC 1123 format (`connection_timers`)
-  - Each item containing, the time of their last connection `time`, their player number `player`, and their team `team`
-- A list of the current [ClientStatus](network%20protocol.md#clientstatus) of each player (`player_status`)
-  - Each item will contain, their status `status`, their player number `player`, and their team `team`
+- The total number of checks done by all players (`total_checks_done`)
+- A per player object (`player_data`) with the following keys:
+  - The player's current alias data (`alias`)
+    - Will return `null` if there is no alias set
+  - A list of items the player has received as a [NetworkItem](network%20protocol.md#networkitem) (`items`)
+  - A list of checks done by the player as a list of the location id's (`checked_locations`)
+  - A list of [Hints](network%20protocol.md#hint) data that player has used or received (`hints`)
+  - The time of last activity of the player, formatted in RFC 1123 format (`activity_time`)
+  - The time of last active connection of the player, formatted in RFC 1123 format (`connection_time`)
+  - The current [ClientStatus](network%20protocol.md#clientstatus) of the player (`status`)
+  - The slot number of that player (`player`)
+  - The team number of that player (`team`)
 
 Example:
 ```json
 {
-  "aliases": [
-    {
-      "team": 0,
-      "player": 1,
-      "alias": "Incompetence"
-    },
-    {
-      "team": 0,
-      "player": 2,
-      "alias": "Slot_Name_2"
-    },
-    {
-      "team": 0,
-      "player": 3,
-      "alias": null
-    },
-  ],
-  "player_items_received": [
-    {
-      "team": 0,
-      "player": 1,
-      "items": [
-        [1, 1, 1, 0],
-        [2, 2, 2, 1]
-      ]
-    },
-    {
-      "team": 0,
-      "player": 2,
-      "items": [
-        [1, 1, 1, 2],
-        [2, 2, 2, 0]
-      ]
-    }
-  ],
-  "player_checks_done": [
-    {
-      "team": 0,
-      "player": 1,
-      "locations": [
-        1,
-        2
-      ]
-    },
-    {
-      "team": 0,
-      "player": 2,
-      "locations": [
-        1,
-        2
-      ]
-    }
-  ],
   "total_checks_done": [
     {
       "team": 0,
       "checks_done": 4
     }
   ],
-  "hints": [
+  "player_data": [
     {
-      "team": 0,
+      "activity_time": null,
+      "alias": null,
+      "checked_locations": [],
+      "connection_time": null,
+      "hints": [],
+      "items": [],
+      "status": 30,
       "player": 1,
-      "hints": [
-        [1, 2, 4, 6, 0, "", 4, 0]
-      ]
+      "team": 0
     },
     {
-      "team": 0,
+      "activity_time": null,
+      "alias": null,
+      "checked_locations": [],
+      "connection_time": null,
+      "hints": [],
+      "items": [],
+      "status": 0,
       "player": 2,
-      "hints": []
-    }
-  ],
-  "activity_timers": [
-    {
-      "team": 0,
-      "player": 1,
-      "time": "Fri, 18 Apr 2025 20:35:45 GMT"
-    },
-    {
-      "team": 0,
-      "player": 2,
-      "time": "Fri, 18 Apr 2025 20:42:46 GMT"
-    }
-  ],
-  "connection_timers": [
-    {
-      "team": 0,
-      "player": 1,
-      "time": "Fri, 18 Apr 2025 20:38:25 GMT"
-    },
-    {
-      "team": 0,
-      "player": 2,
-      "time": "Fri, 18 Apr 2025 21:03:00 GMT"
-    }
-  ],
-  "player_status": [
-    {
-      "team": 0,
-      "player": 1,
-      "status": 0
-    },
-    {
-      "team": 0,
-      "player": 2,
-      "status": 0
+      "team": 0
     }
   ]
 }
@@ -421,11 +370,14 @@ Will provide a dict of static tracker data with the following keys:
   - Each item is a named dict of the game's name.
     - Each game contains two keys, the datapackage's checksum hash `checksum`, and the version `version`
   - This hash can then be sent to the datapackage API to receive the appropriate datapackage as necessary
-- A list of number of checks found vs. total checks available per player (`player_locations_total`)
-  - Each list item contains a dict with three keys, the total locations for that slot `total_locations`, their player number `player`, and their team `team`
-  - Same logic as the multitracker template: found = len(player_checks_done.locations) / total = player_locations_total.total_locations (all available checks).
-- The game each player is playing (`player_game`)
-  - Provided as a list of objects with `team`, `player`, and `game`.
+- A per player object (`player_data`) with the following keys:
+  - The game name for that player (`game`)
+  - The number of checks found vs. total checks available per player (`locations_count`)
+    - Same logic as the multitracker template: found = len(checked_locations) / total = locations_count.total_locations (all available checks).
+  - The list of all location ids known for that player (`locations`)
+  - The slot name of that player (`name`)
+  - The slot number of that player (`player`)
+  - The team number of that player (`team`)
 
 Example:
 ```json
@@ -456,28 +408,22 @@ Example:
       "checksum": "6991cbcda7316b65bcb072667f3ee4c4cae71c0b"
     }
   },
-  "player_locations_total": [
+  "player_data": [
     {
+      "game": "Archipelago",
+      "location_count": 0,
+      "locations": [],
+      "name": "Foo",
       "player": 1,
-      "team" : 0,
-      "total_locations": 10
+      "team": 0
     },
     {
+      "game": "The Messenger",
+      "location_count": 106,
+      "locations": [11390976, 11390977, 11390978, 11390979, 11390980, 11390981],
+      "name": "Bar",
       "player": 2,
-      "team" : 0,
-      "total_locations": 20
-    }
-  ],
-  "player_game": [
-    {
-      "team": 0,
-      "player": 1,
-      "game": "Archipelago"
-    },
-    {
-      "team": 0,
-      "player": 2,
-      "game": "The Messenger"
+      "team": 0
     }
   ]
 }

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -38,7 +38,7 @@ These endpoints are used to query details about the running API stack for the We
 
 ### `/version`
 <a name="apiversion"></a>
-In order to provide the ability for applications to verify they have the correct API specs, the running Archipelago Core version, and each API endpoint version, is accessable to you. 
+In order to provide the ability for applications to verify they have the correct API specs, the running Archipelago Core version and each API endpoint version are accessible to you. 
 
 You'll receive a dict that contains two entries:
 - `ap_core_version` will report the running release of the Archipelago server.

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -32,7 +32,7 @@ API calls to these endpoints should not be faster than the listed timer. This wi
 
 ## API Versions
 <a name="apiversion"></a>
-In order to provide the ability for applications to verify they have the correct API specs, each API endpoint is given a `Major` and `Minor` version number via their own `/<endpoint>/version`.  
+In order to provide the ability for applications to verify they have the correct API specs, each API endpoint is given a `major` and `minor` version number via their own `/<endpoint>/version`.  
 Example:
 ```json
 {
@@ -44,7 +44,7 @@ You'll receive a dict that contains two entries:
 - `major` will always report the running release of the Archipelago server.
 - `minor` will report the version of the endpoint that is running.
 
-If your application is programmed for `/tracker/version` `major: 0.6.7` and `minor: 1`, and your application reports something else, you'll know you need to update your application's API spec, and error accordingly.  
+If your application is programmed for a specfic version of the Archipelago API and your query returns a version you haven't accounted for, you should error accordingly, and update your application's API spec.  
 You will also have the ability to support multiple versions of the API spec in this manner. Allowing you to support more than just a single version of Archipelago at a time.
 
 **As changes are made to the API, the minor version may increase independently of the major Archipelago release version.**  

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -7,6 +7,8 @@ The following API requests are formatted as: `https://<Archipelago URL>/api/<end
 The returned data will be formatted in a combination of JSON lists or dicts, with their keys or values being notated in `blocks` (if applicable)
 
 Current endpoints:
+- Core API
+    - [`/version`](#apiversion)
 - Datapackage API
     - [`/datapackage`](#datapackage)
     - [`/datapackage/<string:checksum>`](#datapackagestringchecksum)
@@ -30,27 +32,32 @@ To reduce the strain on an Archipelago WebHost, many API endpoints will cache th
 Each API endpoint will have their "Cache timer" listed under their definition (if any).
 API calls to these endpoints should not be faster than the listed timer. This will result in wasted processing for your client and (more importantly) the Archipelago WebHost, as the data will not be refreshed by the WebHost until the internal timer has elapsed.
 
-## API Versions
+## Core Endpoints
+These endpoints are used to query details about the running API stack for the WebHost. These are server-wide, and not tied to an individual room, seed, tracker, or user.
+
+### `/version`
 <a name="apiversion"></a>
-In order to provide the ability for applications to verify they have the correct API specs, each API endpoint is given a `major` and `minor` version number via their own `/<endpoint>/version`.  
+In order to provide the ability for applications to verify they have the correct API specs, the running Archipelago Core version, and each API endpoint version, is accessable to you. 
+
+You'll receive a dict that contains two entries:
+- `ap_core` will report the running release of the Archipelago server.
+- `tracker_api` will report the version of the tracker endpoint that the WebHost is running.
+
 Example:
 ```json
 {
-    "major": "0.6.7",
-    "minor": "1"
+    "ap_core_version": "0.6.7",
+    "tracker_version": "1"
 }
 ```
-You'll receive a dict that contains two entries:
-- `major` will always report the running release of the Archipelago server.
-- `minor` will report the version of the endpoint that is running.
 
 If your application is programmed for a specfic version of the Archipelago API and your query returns a version you haven't accounted for, you should error accordingly, and update your application's API code.  
 You will also have the ability to support multiple versions of the Archipelago API in this manner. Allowing you to support more than just a single version of Archipelago at a time.
 
-**As changes are made to the API, the minor version may increase independently of the major Archipelago release version.**  
-In most cases, the minor version will always be `1`. However, you should be prepared to handle other minor versions if changes to the API are deployed out-of-release.
+**As changes are made to the API, an endpoint's version may increase independently of the Archipelago Core version.**  
+In most cases, the endpoint's version will always be `1`. However, you should be prepared to handle other versions if changes to the API are deployed out-of-release.
 
-### Historical API Documentation
+#### Historical API Documentation
 Below are the 5 most recent versions of the API spec.
 - [0.6.7](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.7/docs/webhost%20api.md)
 - [0.6.6](https://github.com/ArchipelagoMW/Archipelago/blob/0.6.6/docs/webhost%20api.md) (Note: This was a core security-only release)
@@ -298,11 +305,6 @@ Example:
 ## Tracker Endpoints
 Endpoints to fetch information regarding players of an active WebHost room with the supplied tracker_ID. The tracker ID
 can either be viewed while on a room tracker page, or from the [room's endpoint](#room-endpoints).
-
-### `/tracker/version`
-<a name=tracker_version></a>
-[See API Version](#apiversion)
-
 
 ### `/tracker/<suuid:tracker>`
 <a name=tracker></a>

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -41,8 +41,8 @@ Example:
 }
 ```
 You'll receive a dict that contains two entries:
-- `Major` will always report the running release of the Archipelago server.
-- `Minor` will report the version of the endpoint that is running.
+- `major` will always report the running release of the Archipelago server.
+- `minor` will report the version of the endpoint that is running.
 
 If your application is programmed for `/tracker/version` `major: 0.6.7` and `minor: 1`, and your application reports something else, you'll know you need to update your application's API spec, and error accordingly.  
 You will also have the ability to support multiple versions of the API spec in this manner. Allowing you to support more than just a single version of Archipelago at a time.

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -48,7 +48,7 @@ If your application is programmed for `/tracker/version` `major: 0.6.7` and `min
 You will also have the ability to support multiple versions of the API spec in this manner. Allowing you to support more than just a single version of Archipelago at a time.
 
 **As changes are made to the API, the minor version may increase independently of the major Archipelago release version.**  
-In most of cases, the minor version will always be `1`. However, you should be prepared to handle other minor versions if changes to the API are deployed out-of-release.
+In most cases, the minor version will always be `1`. However, you should be prepared to handle other minor versions if changes to the API are deployed out-of-release.
 
 ### Historical API Documentation
 Below are the 5 most recent versions of the API spec.

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -44,8 +44,8 @@ You'll receive a dict that contains two entries:
 - `major` will always report the running release of the Archipelago server.
 - `minor` will report the version of the endpoint that is running.
 
-If your application is programmed for a specfic version of the Archipelago API and your query returns a version you haven't accounted for, you should error accordingly, and update your application's API spec.  
-You will also have the ability to support multiple versions of the API spec in this manner. Allowing you to support more than just a single version of Archipelago at a time.
+If your application is programmed for a specfic version of the Archipelago API and your query returns a version you haven't accounted for, you should error accordingly, and update your application's API code.  
+You will also have the ability to support multiple versions of the Archipelago API in this manner. Allowing you to support more than just a single version of Archipelago at a time.
 
 **As changes are made to the API, the minor version may increase independently of the major Archipelago release version.**  
 In most cases, the minor version will always be `1`. However, you should be prepared to handle other minor versions if changes to the API are deployed out-of-release.

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -40,14 +40,14 @@ These endpoints are used to query details about the running API stack for the We
 In order to provide the ability for applications to verify they have the correct API specs, the running Archipelago Core version, and each API endpoint version, is accessable to you. 
 
 You'll receive a dict that contains two entries:
-- `ap_core` will report the running release of the Archipelago server.
-- `tracker_api` will report the version of the tracker endpoint that the WebHost is running.
+- `ap_core_version` will report the running release of the Archipelago server.
+- `tracker_api_version` will report the version of the tracker endpoint that the WebHost is running.
 
 Example:
 ```json
 {
     "ap_core_version": "0.6.7",
-    "tracker_version": "1"
+    "tracker_api_version": "1"
 }
 ```
 


### PR DESCRIPTION
Code:  
Removed `/api/tracker/version` and moved versioning to `/api/version` instead.  
(This also easily allows us to just pull the `<endpoint>_version` field directly from the endpoint so it's always up-to-date)  

Renamed `major` / `minor`  naming scheme to self-identifying keys (`ap_core_version` and `tracker_api_version`)  

Docs:  
updated to reflect these changes  
added a new "Core" header to group the version endpoint and others we may add (made it pretty)  
removed /tracker/version docs  